### PR TITLE
feat: extend enemy damage flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
         enemyGirl.src = "enemy_damage.png";
         setTimeout(() => {
           enemyGirl.src = "enemy_normal.png";
-        }, 200);
+        }, 500);
       }
 
       function launchHeartAttack() {


### PR DESCRIPTION
## Summary
- extend enemy damage flash duration to 500ms

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/kawaii_peg/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6890b6c4c9e08330882d344e04de6907