### PR TITLE
Increase defeated girl image size

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,8 +212,8 @@
       z-index: 30;
     }
     #victory-overlay img {
-      max-width: 80%;
-      max-height: 80%;
+      max-width: 90%;
+      max-height: 90%;
       object-fit: contain;
     }
     #retry-button {


### PR DESCRIPTION
## Summary
- make the defeated girl image display larger on the victory overlay

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6890bf0b40a883309f8a0bc256454af1