### PR TITLE
feat: show defeat overlay on player death

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,34 @@
       max-height: 90%;
       object-fit: contain;
     }
+    #game-over-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.6);
+      color: #fff;
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      z-index: 30;
+      text-align: center;
+    }
+    #game-over-overlay h2 {
+      font-size: 48px;
+      margin: 0 0 20px;
+    }
+    #game-over-overlay button {
+      margin-top: 20px;
+      padding: 10px 20px;
+      font-size: 20px;
+      border: 2px solid #ff69b4;
+      background: #fff;
+      color: #ff1493;
+      cursor: pointer;
+    }
     #retry-button {
       margin-top: 20px;
       padding: 10px 20px;
@@ -293,11 +321,16 @@
       <img id="victory-img" src="enemy_defete.png" alt="倒された女の子">
       <button id="retry-button">リトライ</button>
     </div>
+    <div id="game-over-overlay">
+      <h2>gameover😭</h2>
+      <button id="game-over-retry-button">リトライ</button>
+    </div>
   </div>
 
   <div id="version-history">
     <h3>バージョン履歴</h3>
     <ul>
+      <li>v0.9.2 (2025-08-05) プレイヤーHP0で敗北オーバーレイ表示</li>
       <li>v0.9.1 (2025-08-05) 初期ボール数を3に設定</li>
       <li>v0.9 (2025-08-05) 弾数制限とリロードを実装</li>
       <li>v0.8 (2025-08-05) 爆弾ペグ追加</li>
@@ -428,8 +461,11 @@
       const victoryOverlay = document.getElementById("victory-overlay");
       const victoryImg = document.getElementById("victory-img");
       const retryButton = document.getElementById("retry-button");
+      const gameOverOverlay = document.getElementById("game-over-overlay");
+      const gameOverRetryButton = document.getElementById("game-over-retry-button");
       const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
       retryButton.addEventListener("click", () => location.reload());
+      gameOverRetryButton.addEventListener("click", () => location.reload());
 
       function updateHPBar() {
         const percent = Math.max(0, (enemyHP / maxEnemyHP) * 100);
@@ -460,8 +496,10 @@
 
         if (playerHP <= 0) {
           setTimeout(() => {
-            alert("💀やられちゃった… ギャル敗北😭");
-            location.reload();
+            gameOver = true;
+            gameOverOverlay.style.display = "flex";
+            Runner.stop(runner);
+            Render.stop(render);
           }, 200);
         }
       }


### PR DESCRIPTION
## Summary
- add a dark game-over overlay with retry button
- stop engine and render when player HP is depleted
- document the change in version history
- replace "ギャル敗北" text with "gameover" on defeat overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891d60f6b2483309f5272d9cc4ed7c6