### PR TITLE
特殊ボール追加でランダム発射できるようにしたよん

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,29 @@
       max-height: 90%;
       object-fit: contain;
     }
+    #reward-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(255, 255, 255, 0.9);
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      z-index: 30;
+    }
+    .reward-button {
+      margin: 10px;
+      padding: 10px 20px;
+      background: #ff69b4;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 16px;
+    }
     #game-over-overlay {
       position: absolute;
       top: 0;
@@ -329,6 +352,12 @@
     <div id="victory-overlay">
       <img id="victory-img" src="enemy_defete.png" alt="倒された女の子">
       <button id="retry-button">リトライ</button>
+    </div>
+    <div id="reward-overlay">
+      <h2>ご褒美ボール選んでね💖</h2>
+      <button class="reward-button" data-type="split">分裂ボール</button>
+      <button class="reward-button" data-type="heal">回復ボール</button>
+      <button class="reward-button" data-type="big">デカボール</button>
     </div>
     <div id="game-over-overlay">
       <h2>gameover😭</h2>
@@ -454,14 +483,15 @@
         }
       }
 
-      let currentBall = null;
+      let currentBalls = [];
+      let currentShotType = null;
       let playerHP = 100;
       let stage = 1;
       let maxEnemyHP = 200;
       let enemyHP = maxEnemyHP;
       let pendingDamage = 0;
       let gameOver = false;
-      let ammo = 3;
+      let ammo = Array(3).fill("normal");
       const maxAmmo = 3;
 
       const hpFill = document.getElementById("hp-fill");
@@ -473,12 +503,23 @@
       const enemyGirl = document.getElementById("enemy-girl");
       const victoryOverlay = document.getElementById("victory-overlay");
       const victoryImg = document.getElementById("victory-img");
+      const rewardOverlay = document.getElementById("reward-overlay");
       const retryButton = document.getElementById("retry-button");
       const gameOverOverlay = document.getElementById("game-over-overlay");
       const gameOverRetryButton = document.getElementById("game-over-retry-button");
       const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
       retryButton.addEventListener("click", () => location.reload());
       gameOverRetryButton.addEventListener("click", () => location.reload());
+      document.querySelectorAll(".reward-button").forEach(btn => {
+        btn.addEventListener("click", () => {
+          const type = btn.dataset.type;
+          rewardOverlay.style.display = "none";
+          stage++;
+          startStage();
+          ammo.push(type);
+          updateAmmo();
+        });
+      });
 
       function startStage() {
         enemyGirl.src = "enemy_normal.png";
@@ -486,15 +527,11 @@
         maxEnemyHP = 200 + (stage - 1) * 50;
         enemyHP = maxEnemyHP;
         pendingDamage = 0;
-        currentBall = null;
-        ammo = maxAmmo;
+        currentBalls = [];
+        currentShotType = null;
+        ammo = Array(maxAmmo).fill("normal");
         updateHPBar();
         updateAmmo();
-      }
-
-      function nextStage() {
-        stage++;
-        startStage();
       }
 
       function updateHPBar() {
@@ -504,7 +541,7 @@
         hpDisplay.textContent = `${enemyHP} / ${maxEnemyHP}`;
         if (enemyHP <= 0 && !gameOver) {
           setTimeout(() => {
-            nextStage();
+            rewardOverlay.style.display = "flex";
           }, 200);
         }
       }
@@ -530,11 +567,14 @@
 
       function updateAmmo() {
         ammoValue.innerHTML = "";
-        for (let i = 0; i < ammo; i++) {
+        ammo.forEach(type => {
           const icon = document.createElement("span");
           icon.className = "ammo-ball";
+          if (type === "split") icon.style.background = "#dda0dd";
+          else if (type === "heal") icon.style.background = "#90ee90";
+          else if (type === "big") icon.style.background = "#ffa500";
           ammoValue.appendChild(icon);
-        }
+        });
       }
 
       function flashEnemyDamage() {
@@ -609,7 +649,7 @@
 
       function reload() {
         enemyAttack();
-        ammo = maxAmmo;
+        ammo = Array(maxAmmo).fill("normal");
         updateAmmo();
       }
 
@@ -622,14 +662,15 @@
           if (["peg", "peg-yellow", "peg-bomb"].includes(body.label)) {
             const dx = body.position.x - x;
             const dy = body.position.y - y;
-            if (Math.sqrt(dx * dx + dy * dy) <= 80) {
-              World.remove(world, body);
-              let dmg = 10;
-              if (body.label === "peg-yellow") dmg = 20;
-              addedDamage += dmg;
-              showHitSpark(body.position.x, body.position.y);
-            }
+          if (Math.sqrt(dx * dx + dy * dy) <= 80) {
+            World.remove(world, body);
+            let dmg = 10;
+            if (body.label === "peg-yellow") dmg = 20;
+            dmg *= ball.damageMultiplier || 1;
+            addedDamage += dmg;
+            showHitSpark(body.position.x, body.position.y);
           }
+        }
         });
         pendingDamage += addedDamage;
         showDamageText(x, y, "+" + pendingDamage);
@@ -659,26 +700,44 @@
           }
         });
 
-        function shootBall(angle) {
+        function shootBall(angle, type) {
           const power = 10;
-          const ball = Bodies.circle(firePoint.x, firePoint.y, 15, {
-            restitution: 0.9,
-            render: { fillStyle: "#00bfff" },
-            label: "ball"
-          });
-          Body.setVelocity(ball, {
-            x: Math.cos(angle) * power,
-            y: Math.sin(angle) * power
-          });
-          World.add(world, ball);
-          currentBall = ball;
-          ammo--;
+          if (type === "split") {
+            const offset = 0.2;
+            for (let i = -1; i <= 1; i += 2) {
+              const a = angle + i * offset;
+              const ball = Bodies.circle(firePoint.x, firePoint.y, 15, {
+                restitution: 0.9,
+                render: { fillStyle: "#dda0dd" },
+                label: "ball"
+              });
+              ball.damageMultiplier = 0.5;
+              ball.ballType = "split";
+              Body.setVelocity(ball, { x: Math.cos(a) * power, y: Math.sin(a) * power });
+              World.add(world, ball);
+              currentBalls.push(ball);
+            }
+          } else {
+            const radius = type === "big" ? 30 : 15;
+            const color = type === "big" ? "#ffa500" : (type === "heal" ? "#90ee90" : "#00bfff");
+            const ball = Bodies.circle(firePoint.x, firePoint.y, radius, {
+              restitution: 0.9,
+              render: { fillStyle: color },
+              label: "ball"
+            });
+            ball.damageMultiplier = 1;
+            ball.ballType = type;
+            Body.setVelocity(ball, { x: Math.cos(angle) * power, y: Math.sin(angle) * power });
+            World.add(world, ball);
+            currentBalls.push(ball);
+          }
+          currentShotType = type;
           updateAmmo();
         }
 
         window.addEventListener("click", (e) => {
-          if (currentBall || gameOver) return;
-          if (ammo <= 0) {
+          if (currentBalls.length > 0 || gameOver) return;
+          if (ammo.length <= 0) {
             reload();
             return;
           }
@@ -686,14 +745,15 @@
           const dx = e.clientX - rect.left - firePoint.x;
           const dy = e.clientY - rect.top - firePoint.y;
           const angle = Math.atan2(dy, dx);
-          shootBall(angle);
+          const type = ammo.splice(Math.floor(Math.random() * ammo.length), 1)[0];
+          shootBall(angle, type);
         });
 
         window.addEventListener("touchstart", (e) => {
           if (e.touches.length !== 1) return;
           e.preventDefault();
-          if (currentBall || gameOver) return;
-          if (ammo <= 0) {
+          if (currentBalls.length > 0 || gameOver) return;
+          if (ammo.length <= 0) {
             reload();
             return;
           }
@@ -702,7 +762,8 @@
           const dx = touch.clientX - rect.left - firePoint.x;
           const dy = touch.clientY - rect.top - firePoint.y;
           const angle = Math.atan2(dy, dx);
-          shootBall(angle);
+          const type = ammo.splice(Math.floor(Math.random() * ammo.length), 1)[0];
+          shootBall(angle, type);
         });
 
       Events.on(engine, 'collisionStart', (event) => {
@@ -719,8 +780,10 @@
             }
           } else if (labels.includes("ball") && (labels.includes("peg") || labels.includes("peg-yellow"))) {
             const peg = pair.bodyA.label === "ball" ? pair.bodyB : pair.bodyA;
+            const ball = pair.bodyA.label === "ball" ? pair.bodyA : pair.bodyB;
             World.remove(world, peg);
-            const damage = peg.label === "peg-yellow" ? 20 : 10;
+            let damage = peg.label === "peg-yellow" ? 20 : 10;
+            damage *= ball.damageMultiplier || 1;
             pendingDamage += damage;
             showDamageText(peg.position.x, peg.position.y, "+" + pendingDamage);
             showHitSpark(peg.position.x, peg.position.y);
@@ -729,16 +792,25 @@
             const ball = pair.bodyA.label === "ball" ? pair.bodyA : pair.bodyB;
             const { x, y } = ball.position;
             World.remove(world, ball);
-            currentBall = null;
-            const totalDamage = pendingDamage;
-            enemyHP -= totalDamage;
-            updateHPBar();
-            flashEnemyDamage();
-            showDamageText(x, y, "-" + totalDamage);
-            pendingDamage = 0;
-            enemyAttack();
-            showHitSpark(x, y);
-            launchHeartAttack();
+            currentBalls = currentBalls.filter(b => b !== ball);
+            if (currentBalls.length === 0) {
+              const totalDamage = pendingDamage;
+              if (currentShotType === "heal") {
+                playerHP = Math.min(100, playerHP + totalDamage);
+                updatePlayerHP();
+                showDamageText(x, y, "+HP" + totalDamage);
+              } else {
+                enemyHP -= totalDamage;
+                updateHPBar();
+                flashEnemyDamage();
+                showDamageText(x, y, "-" + totalDamage);
+              }
+              pendingDamage = 0;
+              enemyAttack();
+              showHitSpark(x, y);
+              launchHeartAttack();
+              currentShotType = null;
+            }
           }
         });
       });


### PR DESCRIPTION
## 概要
- 敵撃破後に分裂/回復/デカの特殊ボールを選べるようにした
- 弾倉を配列管理にして、発射時にランダムな弾を使用
- 分裂はダメージ半分で2発、回復は与ダメージ分HP回復、デカはサイズ2倍

## テスト
- `npm test` (package.json がなく失敗)


------
https://chatgpt.com/codex/tasks/task_e_6891dde7bb088330a3f39e4474ff17dd