### PR TITLE
fix: stop firing during reward selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,7 +771,7 @@
         }
 
         window.addEventListener("click", (e) => {
-          if (currentBalls.length > 0 || gameOver) return;
+          if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none") return;
           if (ammo.length + specialAmmo.length <= 0) {
             reload();
             return;
@@ -791,7 +791,7 @@
         window.addEventListener("touchstart", (e) => {
           if (e.touches.length !== 1) return;
           e.preventDefault();
-          if (currentBalls.length > 0 || gameOver) return;
+          if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none") return;
           if (ammo.length + specialAmmo.length <= 0) {
             reload();
             return;


### PR DESCRIPTION
## Summary
- don't fire a shot when reward overlay is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e9a9a81c8330a2be46f188860b06