### PR TITLE
feat: add menu screen with start button

### DIFF
--- a/game.js
+++ b/game.js
@@ -125,9 +125,17 @@ window.addEventListener('DOMContentLoaded', () => {
   const gameOverOverlay = document.getElementById("game-over-overlay");
   const gameOverRetryButton = document.getElementById("game-over-retry-button");
   const reloadOverlay = document.getElementById("reload-overlay");
+  const menuOverlay = document.getElementById("menu-overlay");
+  const startButton = document.getElementById("start-button");
   const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
   retryButton.addEventListener("click", () => location.reload());
   gameOverRetryButton.addEventListener("click", () => location.reload());
+  startButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    menuOverlay.style.display = "none";
+    startStage();
+    updatePlayerHP();
+  });
   document.querySelectorAll(".reward-button").forEach(btn => {
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -449,6 +457,4 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  startStage();
-  updatePlayerHP();
 });

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <div id="menu-overlay">
+    <button id="start-button">スタート</button>
+  </div>
   <div id="container">
     <div id="player-hp-container">
       <div id="player-hp-text">HP: <span id="player-hp-value">100</span> / 100</div>

--- a/style.css
+++ b/style.css
@@ -339,3 +339,26 @@ canvas {
   margin: 0;
   padding-left: 20px;
 }
+
+#menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+#start-button {
+  padding: 20px 40px;
+  font-size: 24px;
+  border: 2px solid #ff69b4;
+  background: #fff;
+  color: #ff1493;
+  cursor: pointer;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- add an initial menu overlay with a start button
- style the menu overlay and start button
- wire the start button to initialize the game

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68927edeb97c8330bd36d254676eab72