### PR TITLE
fix: prevent ball firing during start menu

### DIFF
--- a/game.js
+++ b/game.js
@@ -424,7 +424,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     window.addEventListener("click", (e) => {
-      if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none") return;
+      if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" || getComputedStyle(menuOverlay).display !== "none") return;
       if (ammo.length + specialAmmo.length <= 0) {
         reload();
         return;
@@ -444,7 +444,7 @@ window.addEventListener('DOMContentLoaded', () => {
     window.addEventListener("touchstart", (e) => {
       if (e.touches.length !== 1) return;
       e.preventDefault();
-      if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none") return;
+      if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" || getComputedStyle(menuOverlay).display !== "none") return;
       if (ammo.length + specialAmmo.length <= 0) {
         reload();
         return;


### PR DESCRIPTION
## Summary
- avoid shooting balls while the start menu is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892890aedec8330831e3efc5750a358