### PR TITLE
Add main menu with upgrade toggle and progress reset

### DIFF
--- a/game.js
+++ b/game.js
@@ -133,12 +133,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const reloadOverlay = document.getElementById("reload-overlay");
   const menuOverlay = document.getElementById("menu-overlay");
   const startButton = document.getElementById("start-button");
+  const upgradeMenuButton = document.getElementById("upgrade-menu-button");
+  const resetProgressButton = document.getElementById("reset-progress");
   const xpOverlay = document.getElementById("xp-overlay");
   const xpGained = document.getElementById("xp-gained");
   const xpContinueButton = document.getElementById("xp-continue-button");
   const xpValue = document.getElementById("xp-value");
   const upgradeHpButton = document.getElementById("upgrade-hp");
   const upgradeAtkButton = document.getElementById("upgrade-atk");
+  const upgradeMenu = document.getElementById("upgrade-buttons");
   const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
   retryButton.addEventListener("click", () => location.reload());
   gameOverRetryButton.addEventListener("click", () => location.reload());
@@ -148,6 +151,18 @@ window.addEventListener('DOMContentLoaded', () => {
     upgradeAtkButton.textContent = `攻撃アップ Lv${atkLevel} (10XP)`;
   }
   updateMenu();
+
+  upgradeMenuButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    updateMenu();
+    upgradeMenu.style.display = upgradeMenu.style.display === "flex" ? "none" : "flex";
+  });
+
+  resetProgressButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    localStorage.clear();
+    location.reload();
+  });
 
   upgradeHpButton.addEventListener("click", (e) => {
     e.stopPropagation();

--- a/index.html
+++ b/index.html
@@ -8,12 +8,16 @@
 </head>
   <body>
   <div id="menu-overlay">
-    <div id="xp-display">経験値: <span id="xp-value">0</span></div>
+    <div id="main-menu">
+      <button id="start-button" class="menu-option">スタート</button>
+      <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
+      <button id="reset-progress" class="menu-option">進捗リセット</button>
+    </div>
     <div id="upgrade-buttons">
+      <div id="xp-display">経験値: <span id="xp-value">0</span></div>
       <button id="upgrade-hp">HPアップ(+10) 10XP</button>
       <button id="upgrade-atk">攻撃アップ(+10%) 10XP</button>
     </div>
-    <button id="start-button">スタート</button>
   </div>
   <div id="container">
     <div id="player-hp-container">

--- a/style.css
+++ b/style.css
@@ -354,7 +354,14 @@ canvas {
   z-index: 50;
 }
 
-#start-button {
+#main-menu {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.menu-option {
   padding: 20px 40px;
   font-size: 24px;
   border: 2px solid #ff69b4;
@@ -362,6 +369,7 @@ canvas {
   color: #ff1493;
   cursor: pointer;
   border-radius: 8px;
+  margin: 10px 0;
 }
 
 #xp-display {
@@ -371,10 +379,10 @@ canvas {
 }
 
 #upgrade-buttons {
-  display: flex;
+  display: none;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 20px;
+  margin-top: 20px;
 }
 
 #upgrade-buttons button {


### PR DESCRIPTION
## Summary
- add main menu with Start, Upgrade, and Reset options
- show upgrade buttons when Upgrade is clicked and allow progress reset

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928aa8fbf483308320118200594122