### PR TITLE
回復ボールの表示と実際の回復量のズレを修正

### DIFF
--- a/game.js
+++ b/game.js
@@ -497,7 +497,7 @@ window.addEventListener('DOMContentLoaded', () => {
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + atkLevel * 0.1;
         pendingDamage += damage;
-        showDamageText(peg.position.x, peg.position.y, "+" + pendingDamage);
+        showDamageText(peg.position.x, peg.position.y, "+" + damage);
         showHitSpark(peg.position.x, peg.position.y);
       }
       if (labels.includes("ball") && labels.includes("bottom-sensor")) {


### PR DESCRIPTION
## Summary
- ペグ命中時の表示を累積値ではなく各ヒットの値に変更

## Testing
- `npm test` (package.json が存在せず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68928f4703c0833096bccf79fe56ae4a