### PR TITLE
fix: restrict menu overlay to game area

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,19 +7,19 @@
   <link rel="stylesheet" href="style.css">
 </head>
   <body>
-  <div id="menu-overlay">
-    <div id="main-menu">
-      <button id="start-button" class="menu-option">スタート</button>
-      <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
-      <button id="reset-progress" class="menu-option">進捗リセット</button>
-    </div>
-    <div id="upgrade-buttons">
-      <div id="xp-display">経験値: <span id="xp-value">0</span></div>
-      <button id="upgrade-hp">HPアップ(+10) 10XP</button>
-      <button id="upgrade-atk">攻撃アップ(+10%) 10XP</button>
-    </div>
-  </div>
   <div id="container">
+    <div id="menu-overlay">
+      <div id="main-menu">
+        <button id="start-button" class="menu-option">スタート</button>
+        <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
+        <button id="reset-progress" class="menu-option">進捗リセット</button>
+      </div>
+      <div id="upgrade-buttons">
+        <div id="xp-display">経験値: <span id="xp-value">0</span></div>
+        <button id="upgrade-hp">HPアップ(+10) 10XP</button>
+        <button id="upgrade-atk">攻撃アップ(+10%) 10XP</button>
+      </div>
+    </div>
     <div id="player-hp-container">
       <div id="player-hp-text">HP: <span id="player-hp-value">100</span> / <span id="player-hp-max">100</span></div>
       <div id="player-hp-bar">

--- a/style.css
+++ b/style.css
@@ -341,7 +341,7 @@ canvas {
 }
 
 #menu-overlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
## Summary
- show start menu overlay only inside the game container

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689315dc4cd88330b703fbfa08cc1777