### PR TITLE
feat: enable reward selection after victory click and enlarge visuals

### DIFF
--- a/game.js
+++ b/game.js
@@ -237,8 +237,9 @@ window.addEventListener('DOMContentLoaded', () => {
       setTimeout(() => {
         victoryImg.src = defeatImages[Math.floor(Math.random() * defeatImages.length)];
         victoryOverlay.style.display = "flex";
-        setTimeout(() => {
+        const proceed = () => {
           victoryOverlay.style.display = "none";
+          victoryOverlay.removeEventListener("click", proceed);
           if (stage >= 5) {
             const gained = 10;
             permXP += gained;
@@ -248,7 +249,8 @@ window.addEventListener('DOMContentLoaded', () => {
           } else {
             rewardOverlay.style.display = "flex";
           }
-        }, 1000);
+        };
+        victoryOverlay.addEventListener("click", proceed, { once: true });
       }, 200);
     }
   }

--- a/style.css
+++ b/style.css
@@ -254,10 +254,11 @@ canvas {
   align-items: center;
   justify-content: center;
   z-index: 30;
+  cursor: pointer;
 }
 #victory-overlay img {
-  max-width: 90%;
-  max-height: 90%;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
 }
 #reward-overlay {
@@ -371,7 +372,7 @@ canvas {
 
 #game-title {
   font-family: "Pacifico", cursive;
-  font-size: 64px;
+  font-size: 96px;
   color: #ff1493;
   text-shadow: 3px 3px 0 #fff, 6px 6px 0 #ff69b4;
   margin: 0 0 20px;


### PR DESCRIPTION
## Summary
- show bigger defeat image and start menu logo
- let players choose a reward ball after clicking victory image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689329cdb1888330827be11f842f3017