### PR TITLE
feat: persist reward balls across reload

### DIFF
--- a/game.js
+++ b/game.js
@@ -150,6 +150,7 @@ window.addEventListener('DOMContentLoaded', () => {
   function saveSpecialAmmo() {
     localStorage.setItem("specialAmmo", JSON.stringify(specialAmmo));
   }
+  window.addEventListener("beforeunload", saveSpecialAmmo);
   function updateMenu() {
     xpValue.textContent = permXP;
     upgradeHpButton.textContent = `HPアップ Lv${hpLevel} (10XP)`;
@@ -214,6 +215,7 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   function startStage() {
+    specialAmmo = JSON.parse(localStorage.getItem("specialAmmo") || "[]");
     enemyGirl.src = "enemy_normal.png";
     generatePegs(50 + (stage - 1) * 10);
     maxEnemyHP = 100 + (stage - 1) * 100;


### PR DESCRIPTION
## Summary
- reload後もご褒美ボールを持ち越せるようlocalStorage同期

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68932cffebdc8330838eb9c7487028d4