### PR TITLE
回復ボールの回復タイミングを調整

### DIFF
--- a/game.js
+++ b/game.js
@@ -546,22 +546,28 @@ window.addEventListener('DOMContentLoaded', () => {
             totalDamage = Math.min(totalDamage, Math.max(enemyHP, 0));
           }
           if (currentShotType === "heal") {
+            if (enemyHP > 0) {
+              enemyAttack();
+              launchHeartAttack();
+            }
             playerHP = Math.min(playerMaxHP, playerHP + totalDamage);
             updatePlayerHP();
             showDamageText(x, y, "+" + totalDamage, true);
             showHealSpark(x, y);
-          } else if (totalDamage > 0) {
-            enemyHP -= totalDamage;
-            updateHPBar();
-            flashEnemyDamage();
-            showDamageText(x, y, "-" + totalDamage);
-            showHitSpark(x, y);
+          } else {
+            if (totalDamage > 0) {
+              enemyHP -= totalDamage;
+              updateHPBar();
+              flashEnemyDamage();
+              showDamageText(x, y, "-" + totalDamage);
+              showHitSpark(x, y);
+            }
+            if (enemyHP > 0) {
+              enemyAttack();
+              launchHeartAttack();
+            }
           }
           pendingDamage = 0;
-          if (enemyHP > 0) {
-            enemyAttack();
-            launchHeartAttack();
-          }
           currentShotType = null;
         }
       }


### PR DESCRIPTION
## Summary
- 敵の反撃ダメージを受けた後に回復ボールのHP回復を適用するように変更

## Testing
- `node --check game.js`
- `npm test` (package.json がなく失敗)

------
https://chatgpt.com/codex/tasks/task_e_68932e923ce08330a34ed698456e1a7b