### PR TITLE
Delay special ammo save until shot completes

### DIFF
--- a/game.js
+++ b/game.js
@@ -481,7 +481,6 @@ window.addEventListener('DOMContentLoaded', () => {
       const type = idx < specialAmmo.length
         ? specialAmmo.splice(idx, 1)[0]
         : ammo.splice(idx - specialAmmo.length, 1)[0];
-      saveSpecialAmmo();
       shootBall(angle, type);
     });
 
@@ -503,7 +502,6 @@ window.addEventListener('DOMContentLoaded', () => {
       const type = idx < specialAmmo.length
         ? specialAmmo.splice(idx, 1)[0]
         : ammo.splice(idx - specialAmmo.length, 1)[0];
-      saveSpecialAmmo();
       shootBall(angle, type);
     });
 
@@ -568,6 +566,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }
           pendingDamage = 0;
           currentShotType = null;
+          saveSpecialAmmo();
         }
       }
     });


### PR DESCRIPTION
## Summary
- Defer saving special ammo removal until a shot fully resolves so reward balls return on page reload

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_6893383cd1508330af76028547f2c0a5