### PR TITLE
リロードでご褒美ボールが消えないよう修正

### DIFF
--- a/game.js
+++ b/game.js
@@ -377,6 +377,7 @@ window.addEventListener('DOMContentLoaded', () => {
       enemyAttack();
       ammo = Array(maxAmmo).fill("normal");
       updateAmmo();
+      saveSpecialAmmo();
       reloadOverlay.style.display = "none";
       reloading = false;
     }, 2000);
@@ -468,7 +469,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     window.addEventListener("click", (e) => {
       if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" || getComputedStyle(menuOverlay).display !== "none") return;
-      if (ammo.length + specialAmmo.length <= 0) {
+      if (ammo.length <= 0) {
         reload();
         return;
       }
@@ -488,7 +489,7 @@ window.addEventListener('DOMContentLoaded', () => {
       if (e.touches.length !== 1) return;
       e.preventDefault();
       if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" || getComputedStyle(menuOverlay).display !== "none") return;
-      if (ammo.length + specialAmmo.length <= 0) {
+      if (ammo.length <= 0) {
         reload();
         return;
       }


### PR DESCRIPTION
## Summary
- リロード処理でスペシャル弾をセーブ
- リロード判定を通常弾のみ参照するよう変更

## Testing
- `node --check game.js`
- `npm test` *(package.json が無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68933d33eaec83309f52c7e63a690a64