### PR TITLE
feat: add deck editing

### DIFF
--- a/game.js
+++ b/game.js
@@ -106,11 +106,17 @@ window.addEventListener('DOMContentLoaded', () => {
   let enemyHP = maxEnemyHP;
   let pendingDamage = 0;
   let gameOver = false;
-  let ammo = Array(3).fill("normal");
   const maxAmmo = 3;
-  let specialAmmo = JSON.parse(localStorage.getItem("specialAmmo") || "[]");
-  // ensure stored value exists so reloading the page doesn't drop rewards
-  saveSpecialAmmo();
+  let ammo = [];
+  let ownedBalls = JSON.parse(localStorage.getItem("ownedBalls") || "[]");
+  let deck = JSON.parse(localStorage.getItem("deck") || "[]");
+  if (deck.length === 0) deck = Array(maxAmmo).fill("normal");
+  while (deck.length < maxAmmo) deck.push("normal");
+  function saveDeckData() {
+    localStorage.setItem("ownedBalls", JSON.stringify(ownedBalls));
+    localStorage.setItem("deck", JSON.stringify(deck));
+  }
+  saveDeckData();
   let reloading = false;
 
   let permXP = parseInt(localStorage.getItem("permXP") || "0");
@@ -144,15 +150,16 @@ window.addEventListener('DOMContentLoaded', () => {
   const upgradeHpButton = document.getElementById("upgrade-hp");
   const upgradeAtkButton = document.getElementById("upgrade-atk");
   const upgradeMenu = document.getElementById("upgrade-buttons");
+  const deckOverlay = document.getElementById("deck-overlay");
+  const deckButton = document.getElementById("deck-edit-button");
+  const closeDeckButton = document.getElementById("close-deck");
+  const ownedList = document.getElementById("owned-balls");
+  const deckSlots = document.getElementById("deck-slots");
   const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
   retryButton.style.display = "none";
   retryButton.addEventListener("click", () => location.reload());
   gameOverRetryButton.addEventListener("click", () => location.reload());
-
-  function saveSpecialAmmo() {
-    localStorage.setItem("specialAmmo", JSON.stringify(specialAmmo));
-  }
-  window.addEventListener("beforeunload", saveSpecialAmmo);
+  window.addEventListener("beforeunload", saveDeckData);
   function updateMenu() {
     xpValue.textContent = permXP;
     upgradeHpButton.textContent = `HPアップ Lv${hpLevel} (10XP)`;
@@ -194,6 +201,58 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  function getBallColor(type) {
+    if (type === "split") return "#dda0dd";
+    if (type === "heal") return "#90ee90";
+    if (type === "big") return "#ffa500";
+    return "#00bfff";
+  }
+
+  function renderDeckEditor() {
+    ownedList.innerHTML = "";
+    deckSlots.innerHTML = "";
+    ownedBalls.forEach((type, idx) => {
+      const div = document.createElement("div");
+      div.className = "ball-item";
+      div.style.background = getBallColor(type);
+      div.addEventListener("click", () => {
+        const slot = deck.indexOf("normal");
+        if (slot !== -1) {
+          deck[slot] = type;
+          ownedBalls.splice(idx, 1);
+          saveDeckData();
+          renderDeckEditor();
+        }
+      });
+      ownedList.appendChild(div);
+    });
+    deck.forEach((type, idx) => {
+      const div = document.createElement("div");
+      div.className = "ball-item";
+      div.style.background = getBallColor(type);
+      div.addEventListener("click", () => {
+        if (type !== "normal") {
+          ownedBalls.push(type);
+          deck[idx] = "normal";
+          saveDeckData();
+          renderDeckEditor();
+        }
+      });
+      deckSlots.appendChild(div);
+    });
+  }
+
+  deckButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    renderDeckEditor();
+    deckOverlay.style.display = "flex";
+  });
+
+  closeDeckButton.addEventListener("click", (e) => {
+    e.stopPropagation();
+    deckOverlay.style.display = "none";
+  });
+
   startButton.addEventListener("click", (e) => {
     e.stopPropagation();
     menuOverlay.style.display = "none";
@@ -210,8 +269,8 @@ window.addEventListener('DOMContentLoaded', () => {
       rewardOverlay.style.display = "none";
       stage++;
       if (stage > 5) stage = 5;
-      specialAmmo.push(type);
-      saveSpecialAmmo();
+      ownedBalls.push(type);
+      saveDeckData();
       startStage();
     });
   });
@@ -224,10 +283,9 @@ window.addEventListener('DOMContentLoaded', () => {
     pendingDamage = 0;
     currentBalls = [];
     currentShotType = null;
-    ammo = Array(maxAmmo).fill("normal");
+    ammo = deck.slice();
     updateHPBar();
     updateAmmo();
-    saveSpecialAmmo();
     stageValue.textContent = stage;
   }
 
@@ -280,7 +338,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   function updateAmmo() {
     ammoValue.innerHTML = "";
-    [...specialAmmo, ...ammo].forEach(type => {
+    ammo.forEach(type => {
       const icon = document.createElement("span");
       icon.className = "ammo-ball";
       if (type === "split") icon.style.background = "#dda0dd";
@@ -377,7 +435,6 @@ window.addEventListener('DOMContentLoaded', () => {
       enemyAttack();
       ammo = Array(maxAmmo).fill("normal");
       updateAmmo();
-      saveSpecialAmmo();
       reloadOverlay.style.display = "none";
       reloading = false;
     }, 2000);
@@ -477,11 +534,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const dx = e.clientX - rect.left - firePoint.x;
       const dy = e.clientY - rect.top - firePoint.y;
       const angle = Math.atan2(dy, dx);
-      const total = ammo.length + specialAmmo.length;
-      const idx = Math.floor(Math.random() * total);
-      const type = idx < specialAmmo.length
-        ? specialAmmo.splice(idx, 1)[0]
-        : ammo.splice(idx - specialAmmo.length, 1)[0];
+      const idx = Math.floor(Math.random() * ammo.length);
+      const type = ammo.splice(idx, 1)[0];
       shootBall(angle, type);
     });
 
@@ -498,11 +552,8 @@ window.addEventListener('DOMContentLoaded', () => {
       const dx = touch.clientX - rect.left - firePoint.x;
       const dy = touch.clientY - rect.top - firePoint.y;
       const angle = Math.atan2(dy, dx);
-      const total = ammo.length + specialAmmo.length;
-      const idx = Math.floor(Math.random() * total);
-      const type = idx < specialAmmo.length
-        ? specialAmmo.splice(idx, 1)[0]
-        : ammo.splice(idx - specialAmmo.length, 1)[0];
+      const idx = Math.floor(Math.random() * ammo.length);
+      const type = ammo.splice(idx, 1)[0];
       shootBall(angle, type);
     });
 
@@ -567,7 +618,6 @@ window.addEventListener('DOMContentLoaded', () => {
           }
           pendingDamage = 0;
           currentShotType = null;
-          saveSpecialAmmo();
         }
       }
     });

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <div id="main-menu">
         <h1 id="game-title">Peggy Girls</h1>
         <button id="start-button" class="menu-option">スタート</button>
+        <button id="deck-edit-button" class="menu-option">デッキ編集</button>
         <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
         <button id="reset-progress" class="menu-option">進捗リセット</button>
       </div>
@@ -60,6 +61,18 @@
     <div id="game-over-overlay">
       <h2>gameover😭</h2>
       <button id="game-over-retry-button">リトライ</button>
+    </div>
+    <div id="deck-overlay">
+      <h2>デッキ編集</h2>
+      <div id="owned-container">
+        <h3>所持ボール</h3>
+        <div id="owned-balls" class="ball-list"></div>
+      </div>
+      <div id="deck-container">
+        <h3>デッキ</h3>
+        <div id="deck-slots" class="ball-list"></div>
+      </div>
+      <button id="close-deck">閉じる</button>
     </div>
     <div id="reload-overlay">リロード中…</div>
   </div>

--- a/style.css
+++ b/style.css
@@ -442,3 +442,34 @@ canvas {
   cursor: pointer;
   border-radius: 8px;
 }
+
+#deck-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+}
+
+.ball-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 10px 0;
+}
+
+.ball-item {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid #ff69b4;
+  margin: 5px;
+  cursor: pointer;
+  background: #00bfff;
+}


### PR DESCRIPTION
## Summary
- add deck editing overlay and button
- persist owned balls and deck data
- load stage ammo from deck

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933fa270548330893d4bbe56814f94