### PR TITLE
feat: add ball leveling system

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       <div id="player-hp-bar">
         <div id="player-hp-fill"></div>
       </div>
-      <div id="ammo-text">弾: <span id="ammo-value"></span></div>
+      <div id="ammo-text">弾: <span id="ammo-value" class="ammo-value"></span></div>
     </div>
     <div id="game-wrapper">
       <svg id="aim-svg" width="880" height="700" style="position:absolute;top:0;left:0;z-index:5;"></svg>

--- a/style.css
+++ b/style.css
@@ -75,6 +75,9 @@ html, body {
   color: #ff1493;
   margin-top: 4px;
 }
+.ammo-value {
+  display: inline-block;
+}
 #stage-text {
   font-size: 20px;
   font-weight: bold;
@@ -89,6 +92,19 @@ html, body {
   background: #00bfff;
   border: 1px solid #ff69b4;
   margin-right: 4px;
+  position: relative;
+}
+
+.level-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background: #ff1493;
+  color: #fff;
+  font-size: 10px;
+  border-radius: 50%;
+  padding: 0 3px;
+  line-height: 1;
 }
 .hp-container {
   display: flex;


### PR DESCRIPTION
## Summary
- track ball levels in localStorage and show them as badges
- scale ball size and damage by level when shooting
- picking same reward now levels up that ball

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_68934131f9948330a307cf9ecbe26189