### PR TITLE
Auto-expand deck with reward balls

### DIFF
--- a/game.js
+++ b/game.js
@@ -106,24 +106,9 @@ window.addEventListener('DOMContentLoaded', () => {
   let enemyHP = maxEnemyHP;
   let pendingDamage = 0;
   let gameOver = false;
-  const maxAmmo = 3;
   let ammo = [];
-  let ownedBalls = JSON.parse(localStorage.getItem("ownedBalls") || "[]");
-  ownedBalls = Array.from(new Set(ownedBalls));
-  let deck = JSON.parse(localStorage.getItem("deck") || "[]");
-  let ballLevels = JSON.parse(localStorage.getItem("ballLevels") || "{}");
-  if (deck.length === 0) deck = Array(maxAmmo).fill("normal");
-  while (deck.length < maxAmmo) deck.push("normal");
-  if (!ballLevels["normal"]) ballLevels["normal"] = 1;
-  ownedBalls.forEach(type => {
-    if (!ballLevels[type]) ballLevels[type] = 1;
-  });
-  function saveDeckData() {
-    localStorage.setItem("ownedBalls", JSON.stringify(ownedBalls));
-    localStorage.setItem("deck", JSON.stringify(deck));
-    localStorage.setItem("ballLevels", JSON.stringify(ballLevels));
-  }
-  saveDeckData();
+  let ownedBalls = [];
+  let ballLevels = { normal: 1 };
   let reloading = false;
 
   let permXP = parseInt(localStorage.getItem("permXP") || "0");
@@ -157,16 +142,10 @@ window.addEventListener('DOMContentLoaded', () => {
   const upgradeHpButton = document.getElementById("upgrade-hp");
   const upgradeAtkButton = document.getElementById("upgrade-atk");
   const upgradeMenu = document.getElementById("upgrade-buttons");
-  const deckOverlay = document.getElementById("deck-overlay");
-  const deckButton = document.getElementById("deck-edit-button");
-  const closeDeckButton = document.getElementById("close-deck");
-  const ownedList = document.getElementById("owned-balls");
-  const deckSlots = document.getElementById("deck-slots");
   const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
   retryButton.style.display = "none";
   retryButton.addEventListener("click", () => location.reload());
   gameOverRetryButton.addEventListener("click", () => location.reload());
-  window.addEventListener("beforeunload", saveDeckData);
   function updateMenu() {
     xpValue.textContent = permXP;
     upgradeHpButton.textContent = `HPアップ Lv${hpLevel} (10XP)`;
@@ -208,61 +187,13 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  function getBallColor(type) {
-    if (type === "split") return "#dda0dd";
-    if (type === "heal") return "#90ee90";
-    if (type === "big") return "#ffa500";
-    return "#00bfff";
-  }
-
-  function renderDeckEditor() {
-    ownedList.innerHTML = "";
-    deckSlots.innerHTML = "";
-    ownedBalls.forEach((type, idx) => {
-      const div = document.createElement("div");
-      div.className = "ball-item";
-      div.style.background = getBallColor(type);
-      div.addEventListener("click", () => {
-        const slot = deck.indexOf("normal");
-        if (slot !== -1) {
-          deck[slot] = type;
-          ownedBalls.splice(idx, 1);
-          saveDeckData();
-          renderDeckEditor();
-        }
-      });
-      ownedList.appendChild(div);
-    });
-    deck.forEach((type, idx) => {
-      const div = document.createElement("div");
-      div.className = "ball-item";
-      div.style.background = getBallColor(type);
-      div.addEventListener("click", () => {
-        if (type !== "normal") {
-          ownedBalls.push(type);
-          deck[idx] = "normal";
-          saveDeckData();
-          renderDeckEditor();
-        }
-      });
-      deckSlots.appendChild(div);
-    });
-  }
-
-  deckButton.addEventListener("click", (e) => {
-    e.stopPropagation();
-    renderDeckEditor();
-    deckOverlay.style.display = "flex";
-  });
-
-  closeDeckButton.addEventListener("click", (e) => {
-    e.stopPropagation();
-    deckOverlay.style.display = "none";
-  });
 
   startButton.addEventListener("click", (e) => {
     e.stopPropagation();
     menuOverlay.style.display = "none";
+    stage = 1;
+    ownedBalls = ["normal", "normal", "normal"];
+    ballLevels = { normal: 1 };
     playerMaxHP = 100 + hpLevel * 10;
     playerHP = playerMaxHP;
     startStage();
@@ -282,7 +213,6 @@ window.addEventListener('DOMContentLoaded', () => {
         ownedBalls.push(type);
         ballLevels[type] = 1;
       }
-      saveDeckData();
       startStage();
     });
   });
@@ -295,7 +225,7 @@ window.addEventListener('DOMContentLoaded', () => {
     pendingDamage = 0;
     currentBalls = [];
     currentShotType = null;
-    ammo = deck.slice();
+    ammo = ownedBalls.slice();
     updateHPBar();
     updateAmmo();
     stageValue.textContent = stage;
@@ -449,7 +379,7 @@ window.addEventListener('DOMContentLoaded', () => {
     reloadOverlay.style.display = "flex";
     setTimeout(() => {
       enemyAttack();
-      ammo = Array(maxAmmo).fill("normal");
+      ammo = Array(ownedBalls.length).fill("normal");
       updateAmmo();
       reloadOverlay.style.display = "none";
       reloading = false;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
       <div id="main-menu">
         <h1 id="game-title">Peggy Girls</h1>
         <button id="start-button" class="menu-option">スタート</button>
-        <button id="deck-edit-button" class="menu-option">デッキ編集</button>
         <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
         <button id="reset-progress" class="menu-option">進捗リセット</button>
       </div>
@@ -61,18 +60,6 @@
     <div id="game-over-overlay">
       <h2>gameover😭</h2>
       <button id="game-over-retry-button">リトライ</button>
-    </div>
-    <div id="deck-overlay">
-      <h2>デッキ編集</h2>
-      <div id="owned-container">
-        <h3>所持ボール</h3>
-        <div id="owned-balls" class="ball-list"></div>
-      </div>
-      <div id="deck-container">
-        <h3>デッキ</h3>
-        <div id="deck-slots" class="ball-list"></div>
-      </div>
-      <button id="close-deck">閉じる</button>
     </div>
     <div id="reload-overlay">リロード中…</div>
   </div>

--- a/style.css
+++ b/style.css
@@ -459,33 +459,3 @@ canvas {
   border-radius: 8px;
 }
 
-#deck-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(255, 255, 255, 0.9);
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  z-index: 40;
-}
-
-.ball-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin: 10px 0;
-}
-
-.ball-item {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 2px solid #ff69b4;
-  margin: 5px;
-  cursor: pointer;
-  background: #00bfff;
-}


### PR DESCRIPTION
## Summary
- Remove deck editing UI and let runs start with three normal balls
- Auto-add chosen reward balls to the owned deck without limits and launch the next stage
- Reload fills normal ammo equal to total owned balls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893443c004483308379a87a3460e8f5