### PR TITLE
Avoid reload damage after enemy defeat

### DIFF
--- a/game.js
+++ b/game.js
@@ -378,7 +378,9 @@ window.addEventListener('DOMContentLoaded', () => {
     reloading = true;
     reloadOverlay.style.display = "flex";
     setTimeout(() => {
-      enemyAttack();
+      if (enemyHP > 0) {
+        enemyAttack();
+      }
       ammo = Array(ownedBalls.length).fill("normal");
       updateAmmo();
       reloadOverlay.style.display = "none";


### PR DESCRIPTION
## Summary
- Skip enemyAttack during reload when enemy HP is depleted to prevent unintended player damage

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68934d867dc48330a5c20931c18e1221