### PR TITLE
Copy owned balls into ammo on reload

### DIFF
--- a/game.js
+++ b/game.js
@@ -381,7 +381,7 @@ window.addEventListener('DOMContentLoaded', () => {
       if (enemyHP > 0) {
         enemyAttack();
       }
-      ammo = Array(ownedBalls.length).fill("normal");
+      ammo = ownedBalls.slice();
       updateAmmo();
       reloadOverlay.style.display = "none";
       reloading = false;


### PR DESCRIPTION
## Summary
- Use `ownedBalls.slice()` to initialize `ammo` during `reload`
- Call `updateAmmo()` after reloading to refresh UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934f55ccb483308884250949daa350