### PR TITLE
feat: add random events and progress bar

### DIFF
--- a/game.js
+++ b/game.js
@@ -127,6 +127,9 @@ window.addEventListener('DOMContentLoaded', () => {
   const victoryOverlay = document.getElementById("victory-overlay");
   const victoryImg = document.getElementById("victory-img");
   const rewardOverlay = document.getElementById("reward-overlay");
+  const eventOverlay = document.getElementById("event-overlay");
+  const eventMessage = document.getElementById("event-message");
+  const eventContinueButton = document.getElementById("event-continue-button");
   const retryButton = document.getElementById("retry-button");
   const gameOverOverlay = document.getElementById("game-over-overlay");
   const gameOverRetryButton = document.getElementById("game-over-retry-button");
@@ -142,6 +145,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const upgradeHpButton = document.getElementById("upgrade-hp");
   const upgradeAtkButton = document.getElementById("upgrade-atk");
   const upgradeMenu = document.getElementById("upgrade-buttons");
+  const progressFill = document.getElementById("progress-fill");
   const defeatImages = ["enemy_defete.png", "enemy_defete2.png"];
   retryButton.style.display = "none";
   retryButton.addEventListener("click", () => location.reload());
@@ -213,9 +217,46 @@ window.addEventListener('DOMContentLoaded', () => {
         ownedBalls.push(type);
         ballLevels[type] = 1;
       }
-      startStage();
+      triggerRandomEvent();
     });
   });
+
+  function updateProgress() {
+    const percent = Math.max(0, Math.min(100, ((stage - 1) / 5) * 100));
+    progressFill.style.height = `${percent}%`;
+  }
+
+  function triggerRandomEvent() {
+    const events = ["power", "remove", "duplicate", "heal"];
+    const ev = events[Math.floor(Math.random() * events.length)];
+    if (ev === "power") {
+      const type = ownedBalls[Math.floor(Math.random() * ownedBalls.length)];
+      ballLevels[type] = (ballLevels[type] || 1) + 1;
+      eventMessage.textContent = `${type}ボールがパワーアップしたよ！`;
+    } else if (ev === "remove") {
+      if (ownedBalls.length > 1) {
+        const idx = Math.floor(Math.random() * ownedBalls.length);
+        const removed = ownedBalls.splice(idx, 1)[0];
+        eventMessage.textContent = `${removed}ボールが消えちゃった…`;
+      } else {
+        eventMessage.textContent = `何も起こらなかった…`;
+      }
+    } else if (ev === "duplicate") {
+      const type = ownedBalls[Math.floor(Math.random() * ownedBalls.length)];
+      ownedBalls.push(type);
+      eventMessage.textContent = `${type}ボールが増えたよ！`;
+    } else if (ev === "heal") {
+      const heal = 20;
+      playerHP = Math.min(playerMaxHP, playerHP + heal);
+      updatePlayerHP();
+      eventMessage.textContent = `HPが${heal}回復したよ！`;
+    }
+    eventOverlay.style.display = "flex";
+    eventContinueButton.onclick = () => {
+      eventOverlay.style.display = "none";
+      startStage();
+    };
+  }
 
   function startStage() {
     enemyGirl.src = "enemy_normal.png";
@@ -229,6 +270,7 @@ window.addEventListener('DOMContentLoaded', () => {
     updateHPBar();
     updateAmmo();
     stageValue.textContent = stage;
+    updateProgress();
   }
 
   function updateHPBar() {
@@ -248,6 +290,7 @@ window.addEventListener('DOMContentLoaded', () => {
             permXP += gained;
             localStorage.setItem("permXP", permXP);
             xpGained.textContent = gained;
+            progressFill.style.height = "100%";
             xpOverlay.style.display = "flex";
           } else {
             rewardOverlay.style.display = "flex";
@@ -420,7 +463,7 @@ window.addEventListener('DOMContentLoaded', () => {
     window.addEventListener("mousemove", (e) => {
       if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" ||
         getComputedStyle(menuOverlay).display !== "none" || getComputedStyle(victoryOverlay).display !== "none" ||
-        getComputedStyle(xpOverlay).display !== "none") return;
+        getComputedStyle(xpOverlay).display !== "none" || getComputedStyle(eventOverlay).display !== "none") return;
       const rect = aimSvg.getBoundingClientRect();
       const dx = e.clientX - rect.left - firePoint.x;
       const dy = e.clientY - rect.top - firePoint.y;
@@ -433,7 +476,7 @@ window.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
         if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" ||
           getComputedStyle(menuOverlay).display !== "none" || getComputedStyle(victoryOverlay).display !== "none" ||
-          getComputedStyle(xpOverlay).display !== "none") return;
+          getComputedStyle(xpOverlay).display !== "none" || getComputedStyle(eventOverlay).display !== "none") return;
         const touch = e.touches[0];
         const rect = aimSvg.getBoundingClientRect();
         const dx = touch.clientX - rect.left - firePoint.x;
@@ -486,7 +529,7 @@ window.addEventListener('DOMContentLoaded', () => {
     window.addEventListener("click", (e) => {
       if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" ||
         getComputedStyle(menuOverlay).display !== "none" || getComputedStyle(victoryOverlay).display !== "none" ||
-        getComputedStyle(xpOverlay).display !== "none") return;
+        getComputedStyle(xpOverlay).display !== "none" || getComputedStyle(eventOverlay).display !== "none") return;
       if (ammo.length <= 0) {
         reload();
         return;
@@ -505,7 +548,7 @@ window.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" ||
         getComputedStyle(menuOverlay).display !== "none" || getComputedStyle(victoryOverlay).display !== "none" ||
-        getComputedStyle(xpOverlay).display !== "none") return;
+        getComputedStyle(xpOverlay).display !== "none" || getComputedStyle(eventOverlay).display !== "none") return;
       if (ammo.length <= 0) {
         reload();
         return;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 </head>
   <body>
   <div id="container">
+    <div id="progress-bar"><div id="progress-fill"></div></div>
     <div id="menu-overlay">
       <div id="main-menu">
         <h1 id="game-title">Peggy Girls</h1>
@@ -52,6 +53,10 @@
       <button class="reward-button" data-type="split">分裂ボール</button>
       <button class="reward-button" data-type="heal">回復ボール</button>
       <button class="reward-button" data-type="big">デカボール</button>
+    </div>
+    <div id="event-overlay">
+      <h2 id="event-message"></h2>
+      <button id="event-continue-button">OK</button>
     </div>
     <div id="xp-overlay">
       <h2>経験値GET! +<span id="xp-gained">0</span></h2>

--- a/style.css
+++ b/style.css
@@ -343,6 +343,46 @@ canvas {
   font-weight: bold;
   z-index: 40;
 }
+#event-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+  text-align: center;
+}
+#event-overlay button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  background: #ff69b4;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+}
+#progress-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 10px;
+  height: 100%;
+  background: #ddd;
+  z-index: 2;
+}
+#progress-fill {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 0;
+  background: #ff69b4;
+}
 #retry-button {
   margin-top: 20px;
   padding: 10px 20px;


### PR DESCRIPTION
## Summary
- insert random event encounters between stages
- show progress bar at screen edge

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_6893512bb79c8330a7ad68ccd049fa76