### PR TITLE
feat: highlight random events

### DIFF
--- a/game.js
+++ b/game.js
@@ -138,6 +138,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const victoryImg = document.getElementById("victory-img");
   const rewardOverlay = document.getElementById("reward-overlay");
   const eventOverlay = document.getElementById("event-overlay");
+  const eventTitle = document.getElementById("event-title");
   const eventMessage = document.getElementById("event-message");
   const eventContinueButton = document.getElementById("event-continue-button");
   const retryButton = document.getElementById("retry-button");
@@ -243,6 +244,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
   function triggerRandomEvent() {
     const events = ["power", "remove", "duplicate", "heal"];
+    const bgColors = [
+      "rgba(255, 255, 255, 0.9)",
+      "rgba(255, 228, 225, 0.9)",
+      "rgba(240, 255, 255, 0.9)",
+      "rgba(255, 240, 245, 0.9)"
+    ];
+    eventOverlay.style.background = bgColors[Math.floor(Math.random() * bgColors.length)];
+    eventTitle.textContent = "ランダムイベント発生☆";
     const ev = events[Math.floor(Math.random() * events.length)];
     if (ev === "power") {
       const type = ownedBalls[Math.floor(Math.random() * ownedBalls.length)];
@@ -267,7 +276,8 @@ window.addEventListener('DOMContentLoaded', () => {
       eventMessage.textContent = `HPが${heal}回復したよ！`;
     }
     eventOverlay.style.display = "flex";
-    eventContinueButton.onclick = () => {
+    eventContinueButton.onclick = (e) => {
+      e.stopPropagation();
       eventOverlay.style.display = "none";
       startStage();
     };

--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
       <button class="reward-button" data-type="big">デカボール</button>
     </div>
     <div id="event-overlay">
-      <h2 id="event-message"></h2>
+      <h2 id="event-title">ランダムイベント発生☆</h2>
+      <p id="event-message"></p>
       <button id="event-continue-button">OK</button>
     </div>
     <div id="xp-overlay">

--- a/style.css
+++ b/style.css
@@ -357,7 +357,12 @@ canvas {
   z-index: 30;
   text-align: center;
 }
-#event-overlay h2 {
+#event-title {
+  color: #ff1493;
+  animation: sparkle 0.8s infinite alternate;
+}
+
+#event-message {
   color: #000;
 }
 #event-overlay button {
@@ -369,6 +374,11 @@ canvas {
   border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
+}
+
+@keyframes sparkle {
+  from { transform: scale(1); }
+  to { transform: scale(1.1); }
 }
 #progress-indicator {
   position: absolute;


### PR DESCRIPTION
## Summary
- make random events pop with a flashy title
- avoid firing a ball when the random event OK is pressed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893576ecf9083308bc336419f8ddc60