### PR TITLE
fix: progress bar overlaps HP bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -383,7 +383,7 @@ canvas {
 #progress-indicator {
   position: absolute;
   left: 10px;
-  top: 10px;
+  top: 90px;
   z-index: 2;
   list-style: none;
   display: flex;


### PR DESCRIPTION
## Summary
- move progress indicator down to avoid clashing with player HP bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689516856c2c83308258b756b7c20349