### PR TITLE
イベントマスを?、敵マスを1〜5表示

### DIFF
--- a/game.js
+++ b/game.js
@@ -246,6 +246,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     function updateProgress() {
       progressIndicator.innerHTML = "";
+      let enemyCount = 1;
       progressSteps.forEach((step, idx) => {
         const li = document.createElement("li");
         if (idx < progressIndex) {
@@ -258,7 +259,12 @@ window.addEventListener('DOMContentLoaded', () => {
         if (idx < progressIndex) {
           circle.innerHTML = "&#10003;";
         } else {
-          circle.textContent = idx + 1;
+          if (step === "ランダムイベント") {
+            circle.textContent = "?";
+          } else {
+            circle.textContent = enemyCount;
+            enemyCount++;
+          }
         }
         li.appendChild(circle);
         progressIndicator.appendChild(li);


### PR DESCRIPTION
## Summary
- 進捗バーでランダムイベントを?表示に
- 敵ステージを1〜5の番号表示に変更

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689698b25ab48330b9ca04cc3eb48877