### PR TITLE
プログレス表示のサイズと間隔を調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -389,7 +389,7 @@ canvas {
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 4px 8px;
   margin: 0;
   background: rgba(255, 255, 255, 0.8);
@@ -407,10 +407,10 @@ canvas {
 
 #progress-indicator li:not(:last-child)::after {
   content: '';
-  width: 16px;
+  width: 10px;
   height: 2px;
   background: #ccc;
-  margin-left: 6px;
+  margin-left: 4px;
   border-radius: 1px;
 }
 
@@ -419,8 +419,8 @@ canvas {
 }
 
 .step-circle {
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -430,7 +430,7 @@ canvas {
   border: 2px solid #ddd;
   color: #999;
   font-weight: bold;
-  font-size: 10px;
+  font-size: 8px;
   transition: all 0.3s;
 }
 


### PR DESCRIPTION
## 概要
- プログレスインジケータを小型化してボール発射位置への被りを軽減
- 各マスの間隔を縮めて表示幅をコンパクトに

## テスト
- `npm test` *(package.json がないため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689699b68aa8833098656a0219fffa72