### PR TITLE
ノーマルボール強化表示の残留を修正

### DIFF
--- a/game.js
+++ b/game.js
@@ -623,12 +623,13 @@ window.addEventListener('DOMContentLoaded', () => {
         ball.ballType = type;
         Body.setVelocity(ball, { x: Math.cos(angle) * power, y: Math.sin(angle) * power });
         World.add(world, ball);
-      currentBalls.push(ball);
+        currentBalls.push(ball);
+      }
+      currentShotType = type;
+      updateAmmo();
+      nextBall = null;
+      updateCurrentBall();
     }
-    currentShotType = type;
-    updateAmmo();
-    selectNextBall();
-  }
 
     window.addEventListener("click", (e) => {
       if (currentBalls.length > 0 || gameOver || getComputedStyle(rewardOverlay).display !== "none" ||
@@ -745,6 +746,7 @@ window.addEventListener('DOMContentLoaded', () => {
           }
           pendingDamage = 0;
           currentShotType = null;
+          selectNextBall();
         }
       }
     });


### PR DESCRIPTION
## Summary
- 発射時に発射位置のボール表示を消去して+1バッジが残らないように調整
- 全てのボールが消えたタイミングで次のボールを選択し表示

## Testing
- `npm test` (package.json が無いため失敗)

------
https://chatgpt.com/codex/tasks/task_e_6896a2e79f0c8330bbba1897dc31b410