### PR TITLE
スタートメニューとUIイベント処理の追加

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -42,5 +42,9 @@ export function enemyAttack() {
   updatePlayerHP();
   showDamageOverlay();
   shakeContainer();
+  if (playerState.playerHP <= 0 && !enemyState.gameOver) {
+    enemyState.gameOver = true;
+    document.getElementById('game-over-overlay').style.display = 'flex';
+  }
 }
 

--- a/main.js
+++ b/main.js
@@ -11,8 +11,101 @@ window.addEventListener('DOMContentLoaded', () => {
   playerState.ballLevels = { normal: 1 };
   playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
   playerState.playerHP = playerState.playerMaxHP;
-  startStage();
   updatePlayerHP();
+
+  const menuOverlay = document.getElementById('menu-overlay');
+  const startButton = document.getElementById('start-button');
+  const upgradeMenuButton = document.getElementById('upgrade-menu-button');
+  const resetButton = document.getElementById('reset-progress');
+  const upgradeButtons = document.getElementById('upgrade-buttons');
+  const mainMenu = document.getElementById('main-menu');
+  const upgradeHP = document.getElementById('upgrade-hp');
+  const upgradeATK = document.getElementById('upgrade-atk');
+  const xpDisplay = document.getElementById('xp-value');
+  const xpOverlay = document.getElementById('xp-overlay');
+  const xpContinue = document.getElementById('xp-continue-button');
+  const rewardOverlay = document.getElementById('reward-overlay');
+  const rewardButtons = document.querySelectorAll('.reward-button');
+  const eventOverlay = document.getElementById('event-overlay');
+  const eventContinue = document.getElementById('event-continue-button');
+  const gameOverOverlay = document.getElementById('game-over-overlay');
+  const gameOverRetry = document.getElementById('game-over-retry-button');
+
+  startButton.addEventListener('click', () => {
+    menuOverlay.style.display = 'none';
+    enemyState.stage = 1;
+    enemyState.gameOver = false;
+    startStage();
+  });
+
+  upgradeMenuButton.addEventListener('click', () => {
+    mainMenu.style.display = 'none';
+    upgradeButtons.style.display = 'flex';
+    xpDisplay.textContent = playerState.permXP;
+  });
+
+  resetButton.addEventListener('click', () => {
+    localStorage.clear();
+    location.reload();
+  });
+
+  upgradeHP.addEventListener('click', () => {
+    if (playerState.permXP >= 10) {
+      playerState.permXP -= 10;
+      playerState.hpLevel += 1;
+      localStorage.setItem('permXP', playerState.permXP);
+      localStorage.setItem('hpLevel', playerState.hpLevel);
+      playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
+      playerState.playerHP = playerState.playerMaxHP;
+      updatePlayerHP();
+      xpDisplay.textContent = playerState.permXP;
+    }
+  });
+
+  upgradeATK.addEventListener('click', () => {
+    if (playerState.permXP >= 10) {
+      playerState.permXP -= 10;
+      playerState.atkLevel += 1;
+      localStorage.setItem('permXP', playerState.permXP);
+      localStorage.setItem('atkLevel', playerState.atkLevel);
+      xpDisplay.textContent = playerState.permXP;
+    }
+  });
+
+  xpContinue.addEventListener('click', () => {
+    xpOverlay.style.display = 'none';
+    menuOverlay.style.display = 'flex';
+    enemyState.stage = 1;
+  });
+
+  rewardButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const type = btn.dataset.type;
+      if (!playerState.ownedBalls.includes(type)) {
+        playerState.ownedBalls.push(type);
+        playerState.ballLevels[type] = 1;
+      }
+      rewardOverlay.style.display = 'none';
+      enemyState.stage += 1;
+      startStage();
+    });
+  });
+
+  eventContinue.addEventListener('click', () => {
+    eventOverlay.style.display = 'none';
+    enemyState.stage += 1;
+    startStage();
+  });
+
+  gameOverRetry.addEventListener('click', () => {
+    gameOverOverlay.style.display = 'none';
+    enemyState.stage = 1;
+    enemyState.gameOver = false;
+    playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
+    playerState.playerHP = playerState.playerMaxHP;
+    updatePlayerHP();
+    startStage();
+  });
 
   window.addEventListener('mousemove', (e) => {
     if (playerState.currentBalls.length > 0 || enemyState.gameOver) return;


### PR DESCRIPTION
## Summary
- スタートボタンでゲーム開始できるようにし、各種メニューのUIイベントを実装
- プレイヤーHPが0になった際に敗北オーバーレイを表示

## Testing
- `npm test` *(package.jsonがなくエラー)*

------
https://chatgpt.com/codex/tasks/task_e_6896c3ddd69c833081e5e38aa476b5b0