### PR TITLE
feat: add animated menu overlay

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,11 +31,25 @@ window.addEventListener('DOMContentLoaded', () => {
   const gameOverOverlay = document.getElementById('game-over-overlay');
   const gameOverRetry = document.getElementById('game-over-retry-button');
 
+  const showOverlay = (overlay) => {
+    overlay.style.display = 'flex';
+    requestAnimationFrame(() => overlay.classList.add('show'));
+  };
+
+  const hideOverlay = (overlay) => {
+    overlay.classList.remove('show');
+    overlay.addEventListener('transitionend', () => {
+      overlay.style.display = 'none';
+    }, { once: true });
+  };
+
+  showOverlay(menuOverlay);
+
   let aimTimer;
 
   startButton.addEventListener('click', (e) => {
     e.stopPropagation();
-    menuOverlay.style.display = 'none';
+    hideOverlay(menuOverlay);
     enemyState.stage = 1;
     enemyState.gameOver = false;
     startStage();
@@ -82,7 +96,7 @@ window.addEventListener('DOMContentLoaded', () => {
   xpContinue.addEventListener('click', (e) => {
     e.stopPropagation();
     xpOverlay.style.display = 'none';
-    menuOverlay.style.display = 'flex';
+    showOverlay(menuOverlay);
     enemyState.stage = 1;
   });
 

--- a/style.css
+++ b/style.css
@@ -493,6 +493,14 @@ canvas {
   align-items: center;
   justify-content: center;
   z-index: 50;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity .3s, transform .3s;
+}
+
+#menu-overlay.show {
+  opacity: 1;
+  transform: scale(1);
 }
 
 #game-title {


### PR DESCRIPTION
## Summary
- add fade/scale transitions for the menu overlay and `show` class
- toggle overlay visibility with `.show` for animated open/close

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ca87789c8330978a16adf18719ef