### PR TITLE
refactor: delegate ball selection to engine

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, firePoint, clearSimulatedPath } from './engine.js';
 import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
-import { updateAmmo, selectNextBall, updatePlayerHP } from './ui.js';
+import { updateAmmo, updatePlayerHP, updateCurrentBall } from './ui.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   initEngine();
@@ -181,6 +181,6 @@ window.addEventListener('DOMContentLoaded', () => {
     clearSimulatedPath();
     updateAmmo();
     playerState.nextBall = null;
-    selectNextBall(firePoint);
+    updateCurrentBall(firePoint);
   });
 });


### PR DESCRIPTION
## Summary
- stop selecting next ball in `main.js` click handler
- clear current ball display and rely on engine's `enemyState.selectNextBall`

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6896cd2d9f808330abcfd3bfc2fa9a7c