### PR TITLE
Hide next ball preview after shooting

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,4 +1,5 @@
 import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchHeartAttack } from './ui.js';
+import { updateCurrentBall } from './ui.js';
 import { playerState } from './player.js';
 import { enemyState } from './enemy.js';
 
@@ -172,6 +173,8 @@ export function shootBall(angle, type) {
     playerState.currentBalls.push(ball);
   }
   playerState.currentShotType = type;
+  playerState.nextBall = null;
+  updateCurrentBall(firePoint);
 }
 
 export function setupCollisionHandler() {

--- a/main.js
+++ b/main.js
@@ -180,7 +180,5 @@ window.addEventListener('DOMContentLoaded', () => {
     clearTimeout(aimTimer);
     clearSimulatedPath();
     updateAmmo();
-    playerState.nextBall = null;
-    updateCurrentBall(firePoint);
   });
 });


### PR DESCRIPTION
## Summary
- Clear next ball preview right after shooting and refresh current ball display
- Remove duplicate preview-clearing logic from click handler

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_6896cf4e1cdc8330b10b022db1448def