### PR TITLE
refactor: pause shooting during victory overlay

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
 import { updateAmmo, updatePlayerHP, updateCurrentBall } from './ui.js';
 
+export let handleShoot;
+
 window.addEventListener('DOMContentLoaded', () => {
   initEngine();
   setupCollisionHandler();
@@ -145,9 +147,11 @@ window.addEventListener('DOMContentLoaded', () => {
     startStage();
   });
 
+  const aimSvg = document.getElementById('aim-svg');
+
   window.addEventListener('mousemove', (e) => {
     if (playerState.currentBalls.length > 0 || enemyState.gameOver) return;
-    const rect = document.getElementById('aim-svg').getBoundingClientRect();
+    const rect = aimSvg.getBoundingClientRect();
     const dx = e.clientX - rect.left - firePoint.x;
     const dy = e.clientY - rect.top - firePoint.y;
     const angle = Math.atan2(dy, dx);
@@ -163,13 +167,13 @@ window.addEventListener('DOMContentLoaded', () => {
     clearSimulatedPath();
   });
 
-  window.addEventListener('click', (e) => {
+  handleShoot = function handleShoot(e) {
     if (playerState.currentBalls.length > 0 || enemyState.gameOver || playerState.reloading) return;
     if (playerState.ammo.length <= 0) {
       startReload();
       return;
     }
-    const rect = document.getElementById('aim-svg').getBoundingClientRect();
+    const rect = aimSvg.getBoundingClientRect();
     const dx = e.clientX - rect.left - firePoint.x;
     const dy = e.clientY - rect.top - firePoint.y;
     const angle = Math.atan2(dy, dx);
@@ -180,5 +184,7 @@ window.addEventListener('DOMContentLoaded', () => {
     clearTimeout(aimTimer);
     clearSimulatedPath();
     updateAmmo();
-  });
+  };
+
+  aimSvg.addEventListener('click', handleShoot);
 });

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,5 @@
 import { playerState } from './player.js';
+import { handleShoot } from './main.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -28,9 +29,11 @@ export function updateHPBar(enemyState) {
     setTimeout(() => {
       victoryImg.src = enemyState.defeatImages[Math.floor(Math.random() * enemyState.defeatImages.length)];
       victoryOverlay.style.display = 'flex';
+      document.getElementById('aim-svg').removeEventListener('click', handleShoot);
       const proceed = () => {
         victoryOverlay.style.display = 'none';
         enemyState.gameOver = false;
+        document.getElementById('aim-svg').addEventListener('click', handleShoot);
         if (enemyState.stage >= 5) {
           const gained = 10;
           playerState.permXP += gained;


### PR DESCRIPTION
## Summary
- refactor click handling into `handleShoot` bound to `#aim-svg`
- temporarily remove shooting listener when victory overlay is shown and restore it after proceeding

## Testing
- `node --check main.js && node --check ui.js`
- manual check that clicking during the victory overlay does not fire a shot

------
https://chatgpt.com/codex/tasks/task_e_6896d0972c888330b1edc46bd358ae87