### PR TITLE
Separate progress indicator step styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -461,8 +461,7 @@ canvas {
   transition: all 0.3s;
 }
 
-#progress-indicator li.done .step-circle,
-#progress-indicator li.current .step-circle {
+#progress-indicator li.done .step-circle {
   background: linear-gradient(135deg, #ff69b4, #ff1493);
   border-color: transparent;
   color: #fff;
@@ -470,6 +469,10 @@ canvas {
 }
 
 #progress-indicator li.current .step-circle {
+  background: linear-gradient(135deg, #ffd700, #ffa500);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 0 6px rgba(255, 215, 0, 0.6);
   animation: pulse 1s infinite;
 }
 #retry-button {


### PR DESCRIPTION
## Summary
- differentiate `li.done` and `li.current` step circle styles
- highlight current step with gold gradient and pulse

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d8b14efc8330ba6e5b475ce9f32b