### PR TITLE
Use textContent for progress steps and style completed circles

### DIFF
--- a/style.css
+++ b/style.css
@@ -462,10 +462,10 @@ canvas {
 }
 
 #progress-indicator li.done .step-circle {
-  background: linear-gradient(135deg, #ff69b4, #ff1493);
+  background: linear-gradient(135deg, #90ee90, #32cd32);
   border-color: transparent;
   color: #fff;
-  box-shadow: 0 0 6px rgba(255, 105, 180, 0.6);
+  box-shadow: 0 0 6px rgba(144, 238, 144, 0.6);
 }
 
 #progress-indicator li.current .step-circle {

--- a/ui.js
+++ b/ui.js
@@ -200,18 +200,16 @@ export function updateProgress(enemyState) {
     } else if (idx === enemyState.progressIndex) {
       li.classList.add('current');
     }
+
     const circle = document.createElement('span');
     circle.classList.add('step-circle');
-    if (idx < enemyState.progressIndex) {
-      circle.innerHTML = '&#10003;';
+    if (step === 'ランダムイベント') {
+      circle.textContent = '?';
     } else {
-      if (step === 'ランダムイベント') {
-        circle.textContent = '?';
-      } else {
-        circle.textContent = enemyCount;
-        enemyCount++;
-      }
+      circle.textContent = enemyCount;
+      enemyCount++;
     }
+
     li.appendChild(circle);
     progressIndicator.appendChild(li);
   });


### PR DESCRIPTION
## Summary
- render progress steps with numbers or question mark via `textContent`
- highlight completed steps with distinct circle color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d9198370833087154b7a548a231a