### PR TITLE
Add collectible coin mechanic

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,4 +1,4 @@
-import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchHeartAttack } from './ui.js';
+import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchHeartAttack, updateCoins } from './ui.js';
 import { updateCurrentBall } from './ui.js';
 import { playerState } from './player.js';
 import { enemyState } from './enemy.js';
@@ -69,14 +69,21 @@ export function generatePegs(count) {
     const y = 150 + Math.random() * (height - 250);
     const r = Math.random();
     let peg;
-    if (r < 0.1) {
+    if (r < 0.05) {
+      peg = Bodies.circle(x, y, 10, {
+        isStatic: true,
+        isSensor: true,
+        render: { fillStyle: '#ffd700' },
+        label: 'coin'
+      });
+    } else if (r < 0.15) {
       peg = Bodies.circle(x, y, 10, {
         isStatic: true,
         render: { fillStyle: '#808080' },
         label: 'peg-bomb'
       });
       peg.bombHits = 0;
-    } else if (r < 0.3) {
+    } else if (r < 0.35) {
       peg = Bodies.circle(x, y, 10, {
         isStatic: true,
         render: { fillStyle: '#ffd700' },
@@ -205,6 +212,13 @@ export function setupCollisionHandler() {
           showHitSpark(peg.position.x, peg.position.y);
         }
         generatePegs(initialPegCount);
+      } else if (labels.includes('ball') && labels.includes('coin')) {
+        const coin = pair.bodyA.label === 'coin' ? pair.bodyA : pair.bodyB;
+        World.remove(world, coin);
+        pegs = pegs.filter(p => p !== coin);
+        playerState.coins += 1;
+        localStorage.setItem('coins', playerState.coins);
+        updateCoins();
       } else if (labels.includes('ball') && (labels.includes('peg') || labels.includes('peg-yellow'))) {
         const peg = pair.bodyA.label === 'ball' ? pair.bodyB : pair.bodyA;
         const ball = pair.bodyA.label === 'ball' ? pair.bodyA : pair.bodyB;

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <div id="player-hp-fill"></div>
       </div>
       <div id="ammo-text">弾: <span id="ammo-value" class="ammo-value"></span></div>
+      <div id="coin-counter"><img id="coin-icon" src="image/coin.png" alt="coin"><span id="coin-value">0</span></div>
     </div>
     <div id="game-wrapper">
       <ol id="progress-indicator"></ol>

--- a/player.js
+++ b/player.js
@@ -10,5 +10,6 @@ export const playerState = {
   reloading: false,
   permXP: parseInt(localStorage.getItem('permXP') || '0'),
   hpLevel: parseInt(localStorage.getItem('hpLevel') || '0'),
-  atkLevel: parseInt(localStorage.getItem('atkLevel') || '0')
+  atkLevel: parseInt(localStorage.getItem('atkLevel') || '0'),
+  coins: parseInt(localStorage.getItem('coins') || '0')
 };

--- a/style.css
+++ b/style.css
@@ -78,6 +78,19 @@ html, body {
 .ammo-value {
   display: inline-block;
 }
+#coin-counter {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: bold;
+  color: #ff1493;
+  margin-top: 4px;
+}
+#coin-counter img {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+}
 #current-ball {
   position: absolute;
   left: 0;

--- a/ui.js
+++ b/ui.js
@@ -8,6 +8,7 @@ const playerHpValue = document.getElementById('player-hp-value');
 const playerHpMaxText = document.getElementById('player-hp-max');
 const playerHpFill = document.getElementById('player-hp-fill');
 const ammoValue = document.getElementById('ammo-value');
+const coinValue = document.getElementById('coin-value');
 const currentBallEl = document.getElementById('current-ball');
 const enemyGirl = document.getElementById('enemy-girl');
 const victoryOverlay = document.getElementById('victory-overlay');
@@ -77,6 +78,10 @@ export function updateAmmo() {
     }
     ammoValue.appendChild(icon);
   });
+}
+
+export function updateCoins() {
+  coinValue.textContent = playerState.coins;
 }
 
 export function updateCurrentBall(firePoint) {
@@ -214,3 +219,5 @@ export function updateProgress(enemyState) {
     progressIndicator.appendChild(li);
   });
 }
+
+updateCoins();


### PR DESCRIPTION
## Summary
- track player coins with persistent storage
- display coin counter with icon
- spawn coin sensors and award coins on collision

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6896db51a82c8330bd5f037ad051b085