### PR TITLE
feat: add shop overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
       <p id="event-message"></p>
       <div id="event-options"></div>
     </div>
+    <div id="shop-overlay">
+      <h2>ショップだよ☆</h2>
+      <div id="shop-options"></div>
+      <button id="shop-close">やめる</button>
+    </div>
     <div id="xp-overlay">
       <h2>経験値GET! +<span id="xp-gained">0</span></h2>
       <button id="xp-continue-button">メニューへ</button>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, firePoint, clearSimulatedPath } from './engine.js';
 import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
-import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress } from './ui.js';
+import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay } from './ui.js';
 
 const randomEvents = [
   {
@@ -68,6 +68,9 @@ const randomEvents = [
         apply() {}
       }
     ]
+  },
+  {
+    type: 'shop'
   }
 ];
 
@@ -104,6 +107,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const gameOverRetry = document.getElementById('game-over-retry-button');
   const reloadOverlay = document.getElementById('reload-overlay');
   const victoryOverlay = document.getElementById('victory-overlay');
+  const shopOverlay = document.getElementById('shop-overlay');
 
   const overlays = [
     menuOverlay,
@@ -112,7 +116,8 @@ window.addEventListener('DOMContentLoaded', () => {
     eventOverlay,
     gameOverOverlay,
     reloadOverlay,
-    victoryOverlay
+    victoryOverlay,
+    shopOverlay
   ];
 
   const isAnyOverlayVisible = () =>
@@ -144,6 +149,13 @@ window.addEventListener('DOMContentLoaded', () => {
       return;
     }
     const ev = randomEvents[Math.floor(Math.random() * randomEvents.length)];
+    if (ev.type === 'shop') {
+      showShopOverlay(() => {
+        enemyState.stage += 1;
+        startStage();
+      });
+      return;
+    }
     eventMessage.textContent = ev.text;
     eventOptions.innerHTML = '';
     const choices = typeof ev.choices === 'function' ? ev.choices() : ev.choices;

--- a/style.css
+++ b/style.css
@@ -381,6 +381,42 @@ canvas {
   z-index: 30;
   text-align: center;
 }
+#shop-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+  text-align: center;
+}
+#shop-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+}
+.shop-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+}
+#shop-overlay button {
+  margin-top: 10px;
+  padding: 10px 20px;
+  background: #ff69b4;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+}
 #event-title {
   color: #ff1493;
   animation: sparkle 0.8s infinite alternate;

--- a/ui.js
+++ b/ui.js
@@ -17,6 +17,9 @@ const rewardOverlay = document.getElementById('reward-overlay');
 const xpOverlay = document.getElementById('xp-overlay');
 const xpGained = document.getElementById('xp-gained');
 const progressIndicator = document.getElementById('progress-indicator');
+const shopOverlay = document.getElementById('shop-overlay');
+const shopOptions = document.getElementById('shop-options');
+const shopClose = document.getElementById('shop-close');
 
 export { enemyGirl };
 
@@ -82,6 +85,79 @@ export function updateAmmo() {
 
 export function updateCoins() {
   coinValue.textContent = playerState.coins;
+}
+
+const shopData = {
+  normal: { label: 'ノーマル', buy: 10, sell: 5, upgrade: 15 },
+  split: { label: '分裂', buy: 20, sell: 10, upgrade: 30 },
+  heal: { label: '回復', buy: 20, sell: 10, upgrade: 30 },
+  big: { label: 'デカ', buy: 20, sell: 10, upgrade: 30 }
+};
+
+export function showShopOverlay(onDone) {
+  shopOverlay.style.display = 'flex';
+  shopOptions.innerHTML = '';
+  Object.entries(shopData).forEach(([type, data]) => {
+    const div = document.createElement('div');
+    div.className = 'shop-item';
+    const label = document.createElement('span');
+    label.textContent = `${data.label}ボール`;
+    const buyBtn = document.createElement('button');
+    buyBtn.className = 'shop-buy';
+    buyBtn.dataset.type = type;
+    buyBtn.textContent = `購入(${data.buy})`;
+    const sellBtn = document.createElement('button');
+    sellBtn.className = 'shop-sell';
+    sellBtn.dataset.type = type;
+    sellBtn.textContent = `削除(${data.sell})`;
+    const upBtn = document.createElement('button');
+    upBtn.className = 'shop-upgrade';
+    upBtn.dataset.type = type;
+    upBtn.textContent = `強化(${data.upgrade})`;
+    div.appendChild(label);
+    div.appendChild(buyBtn);
+    div.appendChild(sellBtn);
+    div.appendChild(upBtn);
+    shopOptions.appendChild(div);
+  });
+
+  const handleClick = (e) => {
+    const type = e.target.dataset.type;
+    if (!type) return;
+    if (e.target.classList.contains('shop-buy')) {
+      if (playerState.coins >= shopData[type].buy) {
+        playerState.coins -= shopData[type].buy;
+        playerState.ownedBalls.push(type);
+      }
+    } else if (e.target.classList.contains('shop-sell')) {
+      const idx = playerState.ownedBalls.indexOf(type);
+      if (idx !== -1) {
+        playerState.ownedBalls.splice(idx, 1);
+        playerState.coins += shopData[type].sell;
+      }
+    } else if (e.target.classList.contains('shop-upgrade')) {
+      if (playerState.coins >= shopData[type].upgrade) {
+        playerState.coins -= shopData[type].upgrade;
+        playerState.ballLevels[type] = (playerState.ballLevels[type] || 1) + 1;
+      }
+    } else {
+      return;
+    }
+    localStorage.setItem('coins', playerState.coins);
+    shopOptions.removeEventListener('click', handleClick);
+    shopOverlay.style.display = 'none';
+    updateAmmo();
+    updateCoins();
+    onDone && onDone();
+  };
+
+  shopOptions.addEventListener('click', handleClick);
+
+  shopClose.onclick = () => {
+    shopOptions.removeEventListener('click', handleClick);
+    shopOverlay.style.display = 'none';
+    onDone && onDone();
+  };
 }
 
 export function updateCurrentBall(firePoint) {


### PR DESCRIPTION
## Summary
- add shop overlay and styles
- support buying, selling, and upgrading balls
- expose shop as new random event

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd12b0188330bea584e507df7d0d