### PR TITLE
xpクリア後にプレイヤー状態を初期化

### DIFF
--- a/main.js
+++ b/main.js
@@ -269,6 +269,21 @@ window.addEventListener('DOMContentLoaded', () => {
     xpOverlay.style.display = 'none';
     showOverlay(menuOverlay);
     enemyState.stage = 1;
+    enemyState.progressIndex = 0;
+    playerState.ownedBalls = ['normal', 'normal', 'normal'];
+    playerState.ballLevels = { normal: 1 };
+    playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
+    playerState.playerHP = playerState.playerMaxHP;
+    playerState.ammo = playerState.ownedBalls.slice();
+    playerState.currentBalls = [];
+    playerState.currentShotType = null;
+    playerState.nextBall = null;
+    playerState.reloading = false;
+    updatePlayerHP();
+    updateAmmo();
+    updateCurrentBall(firePoint);
+    updateProgress(enemyState);
+    document.getElementById('stage-value').textContent = enemyState.stage;
   });
 
   rewardButtons.forEach(btn => {


### PR DESCRIPTION
## 概要
- ステージ5クリア後のメニュー復帰時にプレイヤー状態をリセット
- HPや弾数、進行度などのUIも初期化

## テスト
- `npm test` (package.json がなく失敗するが確認済み)

------
https://chatgpt.com/codex/tasks/task_e_6896df78979483309a56081357baa2fb