### PR TITLE
feat: add coin sprite and adjust coin counter size

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -73,7 +73,13 @@ export function generatePegs(count) {
       peg = Bodies.circle(x, y, 10, {
         isStatic: true,
         isSensor: true,
-        render: { fillStyle: '#ffd700' },
+        render: {
+          sprite: {
+            texture: 'image/coin.png',
+            xScale: 0.25,
+            yScale: 0.25
+          }
+        },
         label: 'coin'
       });
     } else if (r < 0.15) {

--- a/style.css
+++ b/style.css
@@ -87,8 +87,8 @@ html, body {
   margin-top: 4px;
 }
 #coin-counter img {
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   margin-right: 4px;
 }
 #current-ball {


### PR DESCRIPTION
## Summary
- show coin peg using coin.png sprite scaled down
- adjust coin counter icon size in UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e03ac3988330a2c0fc73d5374633