### PR TITLE
Reset coins on stage restart

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, firePoint, clearSimulatedPath } from './engine.js';
 import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
-import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay } from './ui.js';
+import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay, updateCoins } from './ui.js';
 
 const randomEvents = [
   {
@@ -284,6 +284,9 @@ window.addEventListener('DOMContentLoaded', () => {
     updateCurrentBall(firePoint);
     updateProgress(enemyState);
     document.getElementById('stage-value').textContent = enemyState.stage;
+    playerState.coins = 0;
+    localStorage.setItem('coins', playerState.coins);
+    updateCoins();
   });
 
   rewardButtons.forEach(btn => {


### PR DESCRIPTION
## Summary
- reset coin count, UI, and storage when starting new game via XP overlay

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e1b18a148330900bd97b5d18a988