### PR TITLE
コイン生成チェックとテクスチャパス修正

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -75,7 +75,7 @@ export function generatePegs(count) {
         isSensor: true,
         render: {
           sprite: {
-            texture: 'image/coin.png',
+            texture: './image/coin.png',
             xScale: 0.25,
             yScale: 0.25
           }
@@ -113,6 +113,26 @@ export function generatePegs(count) {
   });
   pegs.push(bluePeg);
   World.add(world, pegs);
+
+  const hasCoin = pegs.some(p => p.label === 'coin');
+  if (!hasCoin) {
+    const cx = 50 + Math.random() * (width - 100);
+    const cy = 150 + Math.random() * (height - 250);
+    const coin = Bodies.circle(cx, cy, 10, {
+      isStatic: true,
+      isSensor: true,
+      render: {
+        sprite: {
+          texture: './image/coin.png',
+          xScale: 0.25,
+          yScale: 0.25
+        }
+      },
+      label: 'coin'
+    });
+    pegs.push(coin);
+    World.add(world, coin);
+  }
 }
 
 export function drawSimulatedPath(angle, speed) {


### PR DESCRIPTION
## Summary
- generatePegsの末尾でコインが無い場合に自動生成
- コインのテクスチャパスを'./image/coin.png'に修正
- コイン取得時にupdateCoins()でUI更新される挙動を確認

## Testing
- `npm test` *(package.jsonが無くテスト未定義)*

------
https://chatgpt.com/codex/tasks/task_e_6896e2b762248330b67f3f531fc92dd0