### PR TITLE
fix: reset state on game over retry

### DIFF
--- a/main.js
+++ b/main.js
@@ -307,9 +307,20 @@ window.addEventListener('DOMContentLoaded', () => {
     gameOverOverlay.style.display = 'none';
     enemyState.stage = 1;
     enemyState.gameOver = false;
+    enemyState.progressIndex = 0;
+    playerState.ownedBalls = ['normal', 'normal', 'normal'];
+    playerState.ballLevels = { normal: 1 };
     playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
     playerState.playerHP = playerState.playerMaxHP;
+    playerState.ammo = playerState.ownedBalls.slice();
+    playerState.currentBalls = [];
+    playerState.currentShotType = null;
+    playerState.nextBall = null;
+    playerState.reloading = false;
     updatePlayerHP();
+    updateAmmo();
+    updateCurrentBall(firePoint);
+    updateProgress(enemyState);
     startStage();
   });
 


### PR DESCRIPTION
## Summary
- reset owned balls, ammo, and related state when retrying after game over
- refresh progress and current ball display on game over retry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e382f5f883308fa7a9e924bf3617