### PR TITLE
コインのスプライトをペグサイズに合わせる

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -76,8 +76,8 @@ export function generatePegs(count) {
         render: {
           sprite: {
             texture: './image/coin.png',
-            xScale: 0.25,
-            yScale: 0.25
+            xScale: 0.04,
+            yScale: 0.04
           }
         },
         label: 'coin'
@@ -124,8 +124,8 @@ export function generatePegs(count) {
       render: {
         sprite: {
           texture: './image/coin.png',
-          xScale: 0.25,
-          yScale: 0.25
+          xScale: 0.04,
+          yScale: 0.04
         }
       },
       label: 'coin'


### PR DESCRIPTION
## Summary
- ゲーム内コイン画像の縮尺を調整し、ペグと同じサイズ感になるように変更

## Testing
- `npm test` (package.json がなく実行不可)

------
https://chatgpt.com/codex/tasks/task_e_6896e46640d883308c5f8e86caa772b9