### PR TITLE
Prevent negative HP display

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -26,8 +26,9 @@ export { enemyGirl };
 export function updateHPBar(enemyState) {
   const percent = Math.max(0, (enemyState.enemyHP / enemyState.maxEnemyHP) * 100);
   hpFill.style.width = `${percent}%`;
-  hpText.textContent = `${enemyState.enemyHP}`;
-  hpDisplay.textContent = `${enemyState.enemyHP} / ${enemyState.maxEnemyHP}`;
+  const hp = Math.max(0, enemyState.enemyHP);
+  hpText.textContent = `${hp}`;
+  hpDisplay.textContent = `${hp} / ${enemyState.maxEnemyHP}`;
   if (enemyState.enemyHP <= 0 && !enemyState.gameOver) {
     enemyState.gameOver = true;
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- Show enemy HP as zero when the internal value goes negative so the UI never shows negatives.

## Testing
- `node --check ui.js`
- `node -e "const elems={};function createElem(){return {style:{},textContent:'',innerHTML:'',dataset:{},classList:{add(){},remove(){},contains(){return false;}},appendChild(){},addEventListener(){},removeEventListener(){}};}global.document={getElementById:id=>elems[id]||(elems[id]=createElem())};global.window={addEventListener(){},getComputedStyle(){return {display:'none'};},requestAnimationFrame(fn){fn();}};global.localStorage={getItem(){return null;},setItem(){}};global.Matter={};import('./ui.js').then(m=>{const enemyState={enemyHP:-5,maxEnemyHP:100,defeatImages:[],gameOver:false,stage:1,progressIndex:0};m.updateHPBar(enemyState);console.log('hpText',elems['hp-text'].textContent);console.log('hpDisplay',elems['hp-display'].textContent);}).catch(e=>console.error(e))"

------
https://chatgpt.com/codex/tasks/task_e_6896e83e8cec8330a3091b2f49bc853f