### PR TITLE
リトライボタンで次ステージへ進行できるように修正

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,7 +100,7 @@ html, body {
   border-radius: 50%;
   z-index: 6;
   pointer-events: none;
-  display: none;
+  display: block;
 }
 #stage-text {
   font-size: 20px;
@@ -532,7 +532,7 @@ canvas {
   background: #fff;
   color: #ff1493;
   cursor: pointer;
-  display: none;
+  display: block;
 }
 #version-history {
   width: 100%;

--- a/ui.js
+++ b/ui.js
@@ -13,6 +13,7 @@ const currentBallEl = document.getElementById('current-ball');
 const enemyGirl = document.getElementById('enemy-girl');
 const victoryOverlay = document.getElementById('victory-overlay');
 const victoryImg = document.getElementById('victory-img');
+const retryButton = document.getElementById('retry-button');
 const rewardOverlay = document.getElementById('reward-overlay');
 const xpOverlay = document.getElementById('xp-overlay');
 const xpGained = document.getElementById('xp-gained');
@@ -51,6 +52,7 @@ export function updateHPBar(enemyState) {
         }
       };
       victoryOverlay.addEventListener('click', (e) => { e.stopPropagation(); proceed(); }, { once: true });
+      retryButton.addEventListener('click', (e) => { e.stopPropagation(); proceed(); }, { once: true });
     }, 200);
   }
 }


### PR DESCRIPTION
## Summary
- victory overlay 内のリトライボタンを取得し、クリックで次ステージへ進む処理を呼び出すようにした
- リトライボタンが表示されるようスタイルを調整

## Testing
- `npm test` (package.json 不存在のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_6896e932066c83309350013118a5745a