### PR TITLE
Remove destroyed pegs from pegs array

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -227,6 +227,7 @@ export function setupCollisionHandler() {
         const peg = pair.bodyA.label === 'peg-blue' ? pair.bodyA : pair.bodyB;
         const ball = pair.bodyA.label === 'ball' ? pair.bodyA : pair.bodyB;
         World.remove(world, peg);
+        pegs = pegs.filter(p => p !== peg);
         let damage = 10;
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + playerState.atkLevel * 0.1;
@@ -249,6 +250,7 @@ export function setupCollisionHandler() {
         const peg = pair.bodyA.label === 'ball' ? pair.bodyB : pair.bodyA;
         const ball = pair.bodyA.label === 'ball' ? pair.bodyA : pair.bodyB;
         World.remove(world, peg);
+        pegs = pegs.filter(p => p !== peg);
         let damage = peg.label === 'peg-yellow' ? 20 : 10;
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + playerState.atkLevel * 0.1;
@@ -311,6 +313,7 @@ export function explodeBomb(peg, ball) {
       const dy = body.position.y - y;
       if (Math.sqrt(dx * dx + dy * dy) <= 80) {
         World.remove(world, body);
+        pegs = pegs.filter(p => p !== body);
         let dmg = body.label === 'peg-yellow' ? 20 : 10;
         dmg *= ball.damageMultiplier || 1;
         dmg *= 1 + playerState.atkLevel * 0.1;


### PR DESCRIPTION
## Summary
- Ensure removed pegs are filtered out of the tracking array after collisions
- Clean up `pegs` list when bombs explode and destroy pegs

## Testing
- `node --check engine.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ea0846248330ad113ed78b600896