### PR TITLE
Reset coins on game restart

### DIFF
--- a/main.js
+++ b/main.js
@@ -217,6 +217,9 @@ window.addEventListener('DOMContentLoaded', () => {
     hideOverlay(menuOverlay);
     enemyState.stage = 1;
     enemyState.gameOver = false;
+    playerState.coins = 0;
+    localStorage.setItem('coins', playerState.coins);
+    updateCoins();
     startStage();
   });
 
@@ -321,6 +324,9 @@ window.addEventListener('DOMContentLoaded', () => {
     updateAmmo();
     updateCurrentBall(firePoint);
     updateProgress(enemyState);
+    playerState.coins = 0;
+    localStorage.setItem('coins', playerState.coins);
+    updateCoins();
     startStage();
   });
 


### PR DESCRIPTION
## Summary
- Reset coin counter when starting a new game
- Reset coin counter after retrying from game over

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896eb97754883308ce3698e01bc532c