### PR TITLE
爆弾ペグのテクスチャをPNGに変更

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -87,9 +87,9 @@ export function generatePegs(count) {
         isStatic: true,
         render: {
           sprite: {
-            texture: './image/bomb.svg',
-            xScale: 0.3,
-            yScale: 0.3
+            texture: './image/bomb.png',
+            xScale: 0.06,
+            yScale: 0.06
           }
         },
         label: 'peg-bomb'


### PR DESCRIPTION
## 概要
- 爆弾ペグのスプライトをSVGからPNGに変更
- 新しい画像サイズに合わせてスケールを調整

## テスト
- `npm test` (package.jsonがないため失敗)
- `npm run build` (package.jsonがないため失敗)

------
https://chatgpt.com/codex/tasks/task_e_6896fe517e0c8330a0bdad8503b50ed0