### PR TITLE
Use alternative bomb sprite after first hit

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -225,7 +225,7 @@ export function setupCollisionHandler() {
         const ball = pair.bodyA.label === 'ball' ? pair.bodyA : pair.bodyB;
         if (!peg.bombHits) {
           peg.bombHits = 1;
-          peg.render.fillStyle = '#ff4500';
+          peg.render.sprite.texture = './image/bomb_2.png';
         } else {
           explodeBomb(peg, ball);
         }


### PR DESCRIPTION
## Summary
- Swap bomb peg color change for sprite switch to `bomb_2.png` on first hit

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897052a91b48330bddaa263a003bf6e