### PR TITLE
回復ボール画像の差し替え

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -6,7 +6,7 @@ import { enemyState } from './enemy.js';
 const { Engine, Render, Runner, World, Bodies, Body, Events, Composite } = Matter;
 const width = 880;
 const height = 700;
-const healBallPath = './image/heart.svg';
+const healBallPath = './image/recovery_ball.png';
 
 let engine;
 let world;

--- a/index.html
+++ b/index.html
@@ -80,7 +80,6 @@
     <div id="credit-overlay">
       <p>Bomb icon by Freepik - Flaticon</p>
       <p><a href="https://www.flaticon.com/free-icons/coin" title="coin icons">Coin icons created by popo2021 - Flaticon</a></p>
-      <p><a href="https://openmoji.org" title="heart icon">Heart icon by OpenMoji – CC BY-SA 4.0</a></p>
       <button id="credit-close">閉じる</button>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- 回復ボールの画像パスを`recovery_ball.png`に変更
- 古いハートアイコンのクレジットを削除

## テスト
- `npm test` (package.json がなく失敗)


------
https://chatgpt.com/codex/tasks/task_e_68971fc964208330a531d313613cbcc0