### PR TITLE
Use image for heal ammo and adjust styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -114,6 +114,8 @@ html, body {
   height: 16px;
   border-radius: 50%;
   background: #00bfff;
+  background-size: cover;
+  background-repeat: no-repeat;
   border: 1px solid #ff69b4;
   margin-right: 4px;
   position: relative;

--- a/ui.js
+++ b/ui.js
@@ -73,7 +73,11 @@ export function updateAmmo() {
     const icon = document.createElement('span');
     icon.className = 'ammo-ball';
     if (type === 'split') icon.style.background = '#dda0dd';
-    else if (type === 'heal') icon.style.background = '#90ee90';
+    else if (type === 'heal') {
+      icon.style.backgroundImage = 'url("./image/recovery_ball.png")';
+      icon.style.backgroundSize = 'cover';
+      icon.style.backgroundRepeat = 'no-repeat';
+    }
     else if (type === 'big') icon.style.background = '#ffa500';
     const lvl = playerState.ballLevels[type] || 1;
     if (lvl > 1) {


### PR DESCRIPTION
## Summary
- Replace heal ammo color with recovery ball image
- Ensure ammo icons cover their span and don't repeat

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689723417db883308c597de3f31091de