### PR TITLE
feat: display heal ball image on current ball

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,6 +101,8 @@ html, body {
   z-index: 6;
   pointer-events: none;
   display: block;
+  background-size: cover;
+  background-repeat: no-repeat;
 }
 #stage-text {
   font-size: 20px;

--- a/ui.js
+++ b/ui.js
@@ -177,15 +177,21 @@ export function updateCurrentBall(firePoint) {
   const sizeMul = 1 + (lvl - 1) * 0.1;
   const base = playerState.nextBall === 'big' ? 30 : 15;
   const radius = base * sizeMul;
-  let color = '#00bfff';
-  if (playerState.nextBall === 'split') color = '#dda0dd';
-  else if (playerState.nextBall === 'heal') color = '#90ee90';
-  else if (playerState.nextBall === 'big') color = '#ffa500';
   currentBallEl.style.width = `${radius * 2}px`;
   currentBallEl.style.height = `${radius * 2}px`;
   currentBallEl.style.left = `${firePoint.x}px`;
   currentBallEl.style.top = `${firePoint.y}px`;
-  currentBallEl.style.background = color;
+  if (playerState.nextBall === 'heal') {
+    currentBallEl.style.backgroundImage = 'url("./image/recovery_ball.png")';
+    currentBallEl.style.backgroundSize = 'cover';
+    currentBallEl.style.backgroundColor = 'transparent';
+  } else {
+    let color = '#00bfff';
+    if (playerState.nextBall === 'split') color = '#dda0dd';
+    else if (playerState.nextBall === 'big') color = '#ffa500';
+    currentBallEl.style.backgroundImage = '';
+    currentBallEl.style.background = color;
+  }
   currentBallEl.style.display = 'block';
   currentBallEl.innerHTML = '';
   if (lvl > 1) {


### PR DESCRIPTION
## Summary
- show recovery ball image when the next shot is a heal ball
- ensure current-ball uses cover and no-repeat for background images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689723e077e8833097a7a09c8a2c8dc7