### PR TITLE
中央管理されたヒールボール画像パスを導入

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+export const healBallPath = './image/recovery_ball.png';

--- a/engine.js
+++ b/engine.js
@@ -2,11 +2,11 @@ import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchH
 import { updateCurrentBall } from './ui.js';
 import { playerState } from './player.js';
 import { enemyState } from './enemy.js';
+import { healBallPath } from './constants.js';
 
 const { Engine, Render, Runner, World, Bodies, Body, Events, Composite } = Matter;
 const width = 880;
 const height = 700;
-const healBallPath = './image/recovery_ball.png';
 
 let engine;
 let world;

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,6 @@
 import { playerState } from './player.js';
 import { handleShoot } from './main.js';
+import { healBallPath } from './constants.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -74,7 +75,7 @@ export function updateAmmo() {
     icon.className = 'ammo-ball';
     if (type === 'split') icon.style.background = '#dda0dd';
     else if (type === 'heal') {
-      icon.style.backgroundImage = 'url("./image/recovery_ball.png")';
+      icon.style.backgroundImage = `url("${healBallPath}")`;
       icon.style.backgroundSize = 'cover';
       icon.style.backgroundRepeat = 'no-repeat';
     }


### PR DESCRIPTION
## Summary
- ヒールボール画像パスを `constants.js` に切り出して共通利用
- `engine.js` と `ui.js` で同じ定数をインポートし利用

## Testing
- `npm test` *(失敗: package.json が存在しません)*

------
https://chatgpt.com/codex/tasks/task_e_6897261232188330bc13c6966c5b36c8