### PR TITLE
ヒールボールのサイズ調整

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -198,7 +198,7 @@ export function shootBall(angle, type) {
       playerState.currentBalls.push(ball);
     }
   } else {
-    const base = type === 'big' ? 30 : 15;
+    const base = type === 'big' ? 30 : (type === 'heal' ? 10 : 15);
     const radius = base * sizeMul;
     const options = {
       restitution: 0.9,


### PR DESCRIPTION
## 概要
- ヒール弾だけ半径を小さめ(10)に設定し、見た目と当たり判定を調整

## テスト
- `node --check engine.js`
- `npm test` (package.json がなく実行不可)

------
https://chatgpt.com/codex/tasks/task_e_68973b41c8f083308d61922149a0b063