### PR TITLE
ゲームオーバー後に敵攻撃を無効化するガード追加

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -38,6 +38,9 @@ export function startStage() {
 }
 
 export function enemyAttack() {
+  if (enemyState.gameOver) {
+    return;
+  }
   playerState.playerHP -= 10;
   updatePlayerHP();
   showDamageOverlay();


### PR DESCRIPTION
## Summary
- 敵の攻撃処理(enemyAttack)にgameOverチェックを追加し、敗北後の追加ダメージを防止

## Testing
- `npm test` (package.json 不在のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68973d77e0c08330ba48a04cab944dbc