### PR TITLE
Specify radix for player state parsing

### DIFF
--- a/player.js
+++ b/player.js
@@ -8,8 +8,8 @@ export const playerState = {
   ballLevels: { normal: 1 },
   nextBall: null,
   reloading: false,
-  permXP: parseInt(localStorage.getItem('permXP') || '0'),
-  hpLevel: parseInt(localStorage.getItem('hpLevel') || '0'),
-  atkLevel: parseInt(localStorage.getItem('atkLevel') || '0'),
-  coins: parseInt(localStorage.getItem('coins') || '0')
+  permXP: parseInt(localStorage.getItem('permXP') || '0', 10),
+  hpLevel: parseInt(localStorage.getItem('hpLevel') || '0', 10),
+  atkLevel: parseInt(localStorage.getItem('atkLevel') || '0', 10),
+  coins: parseInt(localStorage.getItem('coins') || '0', 10)
 };


### PR DESCRIPTION
## Summary
- parse permXP, hpLevel, atkLevel, and coins using base 10

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973df3d0b083309b12e850a082635a