### PR TITLE
Halve shop costs for faster upgrades

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -96,10 +96,10 @@ export function updateCoins() {
 }
 
 const shopData = {
-  normal: { label: 'ノーマル', buy: 10, sell: 5, upgrade: 15 },
-  split: { label: '分裂', buy: 20, sell: 10, upgrade: 30 },
-  heal: { label: '回復', buy: 20, sell: 10, upgrade: 30 },
-  big: { label: 'デカ', buy: 20, sell: 10, upgrade: 30 }
+  normal: { label: 'ノーマル', buy: 5, sell: 5, upgrade: 8 },
+  split: { label: '分裂', buy: 10, sell: 10, upgrade: 15 },
+  heal: { label: '回復', buy: 10, sell: 10, upgrade: 15 },
+  big: { label: 'デカ', buy: 10, sell: 10, upgrade: 15 }
 };
 
 export function showShopOverlay(onDone) {


### PR DESCRIPTION
## Summary
- Reduce purchase and upgrade costs for shop balls to roughly half, speeding up progression.

## Testing
- `node --check ui.js`
- `npm test` *(fails: Could not read package.json)*
- `node --input-type=module` script verifying shop buttons show new costs `["購入(5)","購入(10)","購入(10)","購入(10)"]`


------
https://chatgpt.com/codex/tasks/task_e_6897404d092c83308ba61dffd967de5b