### PR TITLE
Adjust heal ball sizing and sprite scale

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,1 +1,2 @@
 export const healBallPath = './image/recovery_ball.png';
+export const healBallWidth = 512;

--- a/engine.js
+++ b/engine.js
@@ -2,7 +2,7 @@ import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchH
 import { updateCurrentBall } from './ui.js';
 import { playerState } from './player.js';
 import { enemyState } from './enemy.js';
-import { healBallPath } from './constants.js';
+import { healBallPath, healBallWidth } from './constants.js';
 
 const { Engine, Render, Runner, World, Bodies, Body, Events, Composite } = Matter;
 const width = 880;
@@ -198,14 +198,14 @@ export function shootBall(angle, type) {
       playerState.currentBalls.push(ball);
     }
   } else {
-    const base = type === 'big' ? 30 : (type === 'heal' ? 10 : 15);
+    const base = type === 'big' ? 30 : 15;
     const radius = base * sizeMul;
     const options = {
       restitution: 0.9,
       label: 'ball'
     };
     if (type === 'heal') {
-      const scale = (radius * 2) / 100;
+      const scale = (radius * 2) / healBallWidth;
       options.render = {
         sprite: {
           texture: healBallPath,


### PR DESCRIPTION
## Summary
- Remove smaller radius for heal ball and share normal ball size
- Scale heal ball sprite using its actual pixel width
- Expose heal ball image width constant for easier config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897432a35a8833080813f7dfdc369b8