### PR TITLE
fix: update shop item labels to katakana

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -100,9 +100,9 @@ export function updateCoins() {
 
 const shopData = {
   normal: { label: 'ノーマル', buy: 5, sell: 5, upgrade: 8 },
-  split: { label: '分裂', buy: 10, sell: 10, upgrade: 15 },
+  split: { label: 'スプリット', buy: 10, sell: 10, upgrade: 15 },
   heal: { label: '回復', buy: 10, sell: 10, upgrade: 15 },
-  big: { label: 'デカ', buy: 10, sell: 10, upgrade: 15 }
+  big: { label: 'ビッグ', buy: 10, sell: 10, upgrade: 15 }
 };
 
 export function showShopOverlay(onDone) {


### PR DESCRIPTION
## Summary
- change "split" label from 分裂 to スプリット
- change "big" label from デカ to ビッグ

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974633297c8330846a22dafa548b71