### PR TITLE
feat: コイン獲得表示を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,10 @@
     </div>
     <div id="reward-overlay">
       <h2>ご褒美ボール選んでね💖</h2>
+      <div id="reward-coins">
+        <img src="image/coin.png" alt="coin">
+        <span id="reward-coin-value">0</span>コインGET☆
+      </div>
       <button class="reward-button" data-type="split">スプリットボール</button>
       <button class="reward-button" data-type="heal">回復ボール</button>
       <button class="reward-button" data-type="big">ビッグボール</button>

--- a/style.css
+++ b/style.css
@@ -318,6 +318,17 @@ canvas {
   justify-content: center;
   z-index: 30;
 }
+#reward-coins {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 15px;
+}
+#reward-coins img {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+}
 .reward-button {
   margin: 10px;
   padding: 10px 20px;

--- a/ui.js
+++ b/ui.js
@@ -33,8 +33,10 @@ export function updateHPBar(enemyState) {
   hpDisplay.textContent = `${hp} / ${enemyState.maxEnemyHP}`;
   if (enemyState.enemyHP <= 0 && !enemyState.gameOver) {
     enemyState.gameOver = true;
-    playerState.coins += enemyState.stage * 3;
+    const coinsEarned = enemyState.stage * 3;
+    playerState.coins += coinsEarned;
     updateCoins();
+    document.getElementById('reward-coin-value').textContent = coinsEarned;
     localStorage.setItem('coins', playerState.coins);
     setTimeout(() => {
       victoryImg.src = enemyState.defeatImages[Math.floor(Math.random() * enemyState.defeatImages.length)];


### PR DESCRIPTION
## Summary
- 敵撃破時にコイン獲得表示 (#reward-coins) を追加
- スタイル調整で表示をセンターに
- updateHPBarで獲得コインを変数化しオーバーレイに表示

## Testing
- `npm test` (package.json 不在で実行不可)


------
https://chatgpt.com/codex/tasks/task_e_689749b1221883309ffe3d663a90ec60