### PR TITLE
revamp reward overlay to result screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,14 +53,17 @@
       <button id="retry-button">リトライ</button>
     </div>
     <div id="reward-overlay">
-      <h2>ご褒美ボール選んでね💖</h2>
+      <h2 id="result-title">リザルト</h2>
       <div id="reward-coins">
         <img src="image/coin.png" alt="coin">
-        <span id="reward-coin-value">0</span>コインGET☆
+        <span id="reward-coin-value">0</span>コインGET
       </div>
-      <button class="reward-button" data-type="split">スプリットボール</button>
-      <button class="reward-button" data-type="heal">回復ボール</button>
-      <button class="reward-button" data-type="big">ビッグボール</button>
+      <p id="reward-message">報酬ボールを選んでね</p>
+      <div id="reward-buttons">
+        <button class="reward-button" data-type="split">◯</button>
+        <button class="reward-button" data-type="heal">◯</button>
+        <button class="reward-button" data-type="big">◯</button>
+      </div>
     </div>
     <div id="event-overlay">
       <h2 id="event-title">ランダムイベント発生☆</h2>

--- a/style.css
+++ b/style.css
@@ -322,22 +322,31 @@ canvas {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
 }
 #reward-coins img {
   width: 24px;
   height: 24px;
   margin-right: 8px;
 }
+#reward-message {
+  margin: 0 0 15px;
+}
+#reward-buttons {
+  display: flex;
+  gap: 20px;
+}
 .reward-button {
-  margin: 10px;
-  padding: 10px 20px;
+  width: 60px;
+  height: 60px;
   background: #ff69b4;
   color: #fff;
   border: none;
-  border-radius: 8px;
+  border-radius: 50%;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 32px;
+  line-height: 60px;
+  text-align: center;
 }
 #game-over-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- show `リザルト` title and coin GET text
- prompt message to select reward ball
- circle-style reward buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974b7a791083309d94facf80cf88f8