### PR TITLE
Add images and styling for reward buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,9 +58,9 @@
         <img src="image/coin.png" alt="coin">
         <span id="reward-coin-value">0</span>コインGET☆
       </div>
-      <button class="reward-button" data-type="split">スプリットボール</button>
-      <button class="reward-button" data-type="heal">回復ボール</button>
-      <button class="reward-button" data-type="big">ビッグボール</button>
+      <button class="reward-button" data-type="split"><img src="image/split_ball.png" alt="スプリットボール">スプリットボール</button>
+      <button class="reward-button" data-type="heal"><img src="image/recovery_ball.png" alt="回復ボール">回復ボール</button>
+      <button class="reward-button" data-type="big"><img src="image/big_ball.png" alt="ビッグボール">ビッグボール</button>
     </div>
     <div id="event-overlay">
       <h2 id="event-title">ランダムイベント発生☆</h2>

--- a/style.css
+++ b/style.css
@@ -338,6 +338,15 @@ canvas {
   border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.reward-button img {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  display: inline-block;
 }
 #game-over-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- embed reward ball icons in reward selection buttons
- style reward buttons and images for consistent layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/kawaii_peg/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68974c1d60fc83308f07f832626f6cdb