### PR TITLE
feat: add reward button images

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
       </div>
       <p id="reward-message">報酬ボールを選んでね</p>
       <div id="reward-buttons">
-        <button class="reward-button" data-type="split">◯</button>
-        <button class="reward-button" data-type="heal">◯</button>
-        <button class="reward-button" data-type="big">◯</button>
+        <button class="reward-button" data-type="split"><img src="image/split_ball.png" alt="スプリットボール">スプリットボール</button>
+        <button class="reward-button" data-type="heal"><img src="image/recovery_ball.png" alt="回復ボール">回復ボール</button>
+        <button class="reward-button" data-type="big"><img src="image/big_ball.png" alt="ビッグボール">ビッグボール</button>
       </div>
     </div>
     <div id="event-overlay">

--- a/style.css
+++ b/style.css
@@ -337,16 +337,22 @@ canvas {
   gap: 20px;
 }
 .reward-button {
-  width: 60px;
-  height: 60px;
   background: #ff69b4;
   color: #fff;
   border: none;
-  border-radius: 50%;
+  border-radius: 8px;
   cursor: pointer;
-  font-size: 32px;
-  line-height: 60px;
-  text-align: center;
+  font-size: 16px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+}
+
+.reward-button img {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  display: inline-block;
 }
 #game-over-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- embed images for split, recovery and big ball reward buttons
- style reward button images and layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974cddac60833099fd1b0a878aafe1