### PR TITLE
ショップアイテムにボール画像を追加

### DIFF
--- a/style.css
+++ b/style.css
@@ -437,6 +437,11 @@ canvas {
   align-items: center;
   justify-content: center;
 }
+.shop-item img {
+  width: 32px;
+  height: 32px;
+  margin-right: 5px;
+}
 #shop-overlay button {
   margin-top: 10px;
   padding: 10px 20px;

--- a/ui.js
+++ b/ui.js
@@ -112,12 +112,22 @@ const shopData = {
   big: { label: 'ビッグ', buy: 10, sell: 10, upgrade: 15 }
 };
 
+const shopImageMap = {
+  normal: './image/normal_ball.png',
+  split: './image/split_ball.png',
+  heal: healBallPath,
+  big: './image/big_ball.png'
+};
+
 export function showShopOverlay(onDone) {
   shopOverlay.style.display = 'flex';
   shopOptions.innerHTML = '';
   Object.entries(shopData).forEach(([type, data]) => {
     const div = document.createElement('div');
     div.className = 'shop-item';
+    const img = document.createElement('img');
+    img.src = shopImageMap[type];
+    img.alt = `${data.label}ボール`;
     const label = document.createElement('span');
     label.textContent = `${data.label}ボール`;
     const buyBtn = document.createElement('button');
@@ -132,6 +142,7 @@ export function showShopOverlay(onDone) {
     upBtn.className = 'shop-upgrade';
     upBtn.dataset.type = type;
     upBtn.textContent = `強化(${data.upgrade})`;
+    div.appendChild(img);
     div.appendChild(label);
     div.appendChild(buyBtn);
     div.appendChild(sellBtn);


### PR DESCRIPTION
## Summary
- ショップアイテムに対応するボール画像を表示
- ボール種別ごとの画像マッピングを追加
- 画像のレイアウト調整スタイルを追加

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974da9fa8c833089ecad20b0cc931e