### PR TITLE
ショップにコイン表示を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
     </div>
     <div id="shop-overlay">
       <h2>ショップだよ☆</h2>
+      <div id="shop-coin-counter"><img src="image/coin.png" alt="coin"><span id="shop-coin-value">0</span></div>
       <div id="shop-options"></div>
       <button id="shop-close">やめる</button>
     </div>

--- a/style.css
+++ b/style.css
@@ -91,6 +91,18 @@ html, body {
   height: 24px;
   margin-right: 4px;
 }
+#shop-coin-counter {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: bold;
+  color: #ff1493;
+}
+#shop-coin-counter img {
+  width: 24px;
+  height: 24px;
+  margin-right: 4px;
+}
 #current-ball {
   position: absolute;
   left: 0;

--- a/ui.js
+++ b/ui.js
@@ -103,6 +103,10 @@ export function updateAmmo() {
 
 export function updateCoins() {
   coinValue.textContent = playerState.coins;
+  const shopCoinValue = document.getElementById('shop-coin-value');
+  if (shopCoinValue) {
+    shopCoinValue.textContent = playerState.coins;
+  }
 }
 
 const shopData = {
@@ -121,6 +125,7 @@ const shopImageMap = {
 
 export function showShopOverlay(onDone) {
   shopOverlay.style.display = 'flex';
+  updateCoins();
   shopOptions.innerHTML = '';
   Object.entries(shopData).forEach(([type, data]) => {
     const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- ショップ画面にコインカウンターを追加して、所持コインを一目でチェック
- コイン更新関数を拡張し、ショップとメイン画面を同時に反映
- ショップオープン時に最新コイン数を表示

## Testing
- `npm test` *(package.json がなくて失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689757de2fb0833084e84913476dbdf3