### PR TITLE
feat: add vertical reward button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,21 @@
       </div>
       <p id="reward-message">報酬ボールを選んでね</p>
       <div id="reward-buttons">
-        <button class="reward-button" data-type="split"><img src="image/split_ball.png" alt="スプリットボール">スプリットボール</button>
-        <button class="reward-button" data-type="heal"><img src="image/recovery_ball.png" alt="ヒールボール">ヒールボール</button>
-        <button class="reward-button" data-type="big"><img src="image/big_ball.png" alt="ビッグボール">ビッグボール</button>
+        <button class="reward-button" data-type="split">
+          <img src="image/split_ball.png" alt="スプリットボール">
+          <div class="reward-name">スプリットボール</div>
+          <div class="reward-desc">弾が2つに分裂するよ♪</div>
+        </button>
+        <button class="reward-button" data-type="heal">
+          <img src="image/recovery_ball.png" alt="ヒールボール">
+          <div class="reward-name">ヒールボール</div>
+          <div class="reward-desc">当たるとHP回復するよ☆</div>
+        </button>
+        <button class="reward-button" data-type="big">
+          <img src="image/big_ball.png" alt="ビッグボール">
+          <div class="reward-name">ビッグボール</div>
+          <div class="reward-desc">弾がでかくなるよ☆</div>
+        </button>
       </div>
     </div>
     <div id="event-overlay">

--- a/style.css
+++ b/style.css
@@ -357,14 +357,29 @@ canvas {
   font-size: 16px;
   padding: 8px 12px;
   display: flex;
+  flex-direction: column;
   align-items: center;
 }
 
 .reward-button img {
-  width: 24px;
-  height: 24px;
-  margin-right: 8px;
+  width: 64px;
+  height: 64px;
+  margin-bottom: 8px;
   display: inline-block;
+}
+
+.reward-name,
+.reward-desc {
+  text-align: center;
+}
+
+.reward-name {
+  margin-top: 4px;
+}
+
+.reward-desc {
+  font-size: 12px;
+  margin-top: 2px;
 }
 #game-over-overlay {
   position: absolute;


### PR DESCRIPTION
## Summary
- style reward selection buttons vertically with larger icons
- center reward texts and add descriptions for each reward

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689758ef79508330bbf6262d45d2a460