### PR TITLE
feat: add enemy attack countdown

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -1,12 +1,13 @@
 import { playerState } from './player.js';
 import { firePoint, generatePegs } from './engine.js';
-import { updateAmmo, updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, updateProgress, selectNextBall as uiSelectNextBall } from './ui.js';
+import { updateAmmo, updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, updateProgress, selectNextBall as uiSelectNextBall, updateAttackCountdown } from './ui.js';
 
 export const enemyState = {
   stage: 1,
   maxEnemyHP: 100,
   enemyHP: 100,
   pendingDamage: 0,
+  attackCountdown: 0,
   gameOver: false,
   progressSteps: [
     'ステージ1', 'ランダムイベント', 'ステージ2', 'ランダムイベント', 'ステージ3', 'ランダムイベント', 'ステージ4', 'ランダムイベント', 'ステージ5'
@@ -32,9 +33,11 @@ export function startStage() {
   enemyState.updateHPBar();
   updateAmmo();
   uiSelectNextBall(firePoint);
+  enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
   document.getElementById('stage-value').textContent = enemyState.stage;
   enemyState.progressIndex = (enemyState.stage - 1) * 2;
   updateProgress(enemyState);
+  updateAttackCountdown(enemyState);
 }
 
 export function enemyAttack() {
@@ -49,5 +52,7 @@ export function enemyAttack() {
     enemyState.gameOver = true;
     document.getElementById('game-over-overlay').style.display = 'flex';
   }
+  enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
+  updateAttackCountdown(enemyState);
 }
 

--- a/engine.js
+++ b/engine.js
@@ -1,5 +1,6 @@
 import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchHeartAttack, updateCoins } from './ui.js';
 import { updateCurrentBall } from './ui.js';
+import { updateAttackCountdown } from './ui.js';
 import { playerState } from './player.js';
 import { enemyState } from './enemy.js';
 import { healBallPath, healBallWidth } from './constants.js';
@@ -300,10 +301,6 @@ export function setupCollisionHandler() {
             totalDamage = Math.min(totalDamage, Math.max(enemyState.enemyHP, 0));
           }
           if (playerState.currentShotType === 'heal') {
-            if (enemyState.enemyHP > 0) {
-              enemyState.enemyAttack();
-              launchHeartAttack();
-            }
             playerState.playerHP = Math.min(playerState.playerMaxHP, playerState.playerHP + totalDamage);
             enemyState.updatePlayerHP();
             showDamageText(x, y, '+' + totalDamage, true);
@@ -316,13 +313,16 @@ export function setupCollisionHandler() {
               showDamageText(x, y, '-' + totalDamage);
               showHitSpark(x, y);
             }
-            if (enemyState.enemyHP > 0) {
-              enemyState.enemyAttack();
-              launchHeartAttack();
-            }
           }
           enemyState.pendingDamage = 0;
           playerState.currentShotType = null;
+          enemyState.attackCountdown--;
+          if (enemyState.attackCountdown <= 0 && enemyState.enemyHP > 0) {
+            enemyState.enemyAttack();
+            launchHeartAttack();
+          } else {
+            updateAttackCountdown(enemyState);
+          }
           enemyState.selectNextBall();
         }
       }

--- a/index.html
+++ b/index.html
@@ -46,7 +46,10 @@
           <div id="hp-text">200</div>
         </div>
       </div>
-      <img id="enemy-girl" src="image/enemy_normal.png" alt="敵の女の子">
+      <div id="enemy-image-wrapper">
+        <img id="enemy-girl" src="image/enemy_normal.png" alt="敵の女の子">
+        <div id="enemy-attack-timer"></div>
+      </div>
     </div>
     <div id="victory-overlay">
       <img id="victory-img" src="image/enemy_defete.png" alt="倒された女の子">

--- a/style.css
+++ b/style.css
@@ -184,6 +184,20 @@ html, body {
 #enemy-girl {
   width: 400px;
 }
+#enemy-image-wrapper {
+  position: relative;
+}
+#enemy-attack-timer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.8);
+  color: #ff1493;
+  font-weight: bold;
+  padding: 4px 8px;
+  border: 2px solid #ff69b4;
+  border-radius: 4px;
+}
 canvas {
   display: block;
 }

--- a/ui.js
+++ b/ui.js
@@ -25,6 +25,13 @@ const shopClose = document.getElementById('shop-close');
 
 export { enemyGirl };
 
+export function updateAttackCountdown(enemyState) {
+  const timer = document.getElementById('enemy-attack-timer');
+  if (timer) {
+    timer.textContent = enemyState.attackCountdown;
+  }
+}
+
 export function updateHPBar(enemyState) {
   const percent = Math.max(0, (enemyState.enemyHP / enemyState.maxEnemyHP) * 100);
   hpFill.style.width = `${percent}%`;


### PR DESCRIPTION
## Summary
- show enemy's attack timer and reset after each strike
- trigger enemy attack based on countdown instead of every turn

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689759dd8c0c833085f3760d010977b2