### PR TITLE
fix: skip attack countdown on game over

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -51,8 +51,9 @@ export function enemyAttack() {
   if (playerState.playerHP <= 0 && !enemyState.gameOver) {
     enemyState.gameOver = true;
     document.getElementById('game-over-overlay').style.display = 'flex';
+  } else {
+    enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
+    updateAttackCountdown(enemyState);
   }
-  enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
-  updateAttackCountdown(enemyState);
 }
 


### PR DESCRIPTION
## Summary
- avoid resetting attack countdown when the player is defeated

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68975c0ca5b083309f7dc87a3afa097b