### PR TITLE
Allow multiple reward balls

### DIFF
--- a/main.js
+++ b/main.js
@@ -327,8 +327,8 @@ window.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       const type = btn.dataset.type;
-      if (!playerState.ownedBalls.includes(type)) {
-        playerState.ownedBalls.push(type);
+      playerState.ownedBalls.push(type);
+      if (!playerState.ballLevels[type]) {
         playerState.ballLevels[type] = 1;
       }
       rewardOverlay.style.display = 'none';


### PR DESCRIPTION
## Summary
- allow adding multiple reward balls instead of ignoring duplicates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6897c995c1e8833083b9794169837138