### PR TITLE
Remove hidden victory overlay button

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
     </div>
     <div id="victory-overlay">
       <img id="victory-img" src="image/enemy_defeat.png" alt="倒された女の子">
-      <button id="retry-button">リトライ</button>
     </div>
     <div id="reward-overlay">
       <h2 id="result-title">リザルト</h2>

--- a/style.css
+++ b/style.css
@@ -608,16 +608,6 @@ canvas {
   box-shadow: 0 0 6px rgba(255, 215, 0, 0.6);
   animation: pulse 1s infinite;
 }
-#retry-button {
-  margin-top: 20px;
-  padding: 10px 20px;
-  font-size: 20px;
-  border: 2px solid #ff69b4;
-  background: #fff;
-  color: #ff1493;
-  cursor: pointer;
-  display: block;
-}
 #version-history {
   width: 100%;
   max-width: 1280px;

--- a/ui.js
+++ b/ui.js
@@ -14,7 +14,6 @@ const currentBallEl = document.getElementById('current-ball');
 const enemyGirl = document.getElementById('enemy-girl');
 const victoryOverlay = document.getElementById('victory-overlay');
 const victoryImg = document.getElementById('victory-img');
-const retryButton = document.getElementById('retry-button');
 const rewardOverlay = document.getElementById('reward-overlay');
 const xpOverlay = document.getElementById('xp-overlay');
 const xpGained = document.getElementById('xp-gained');
@@ -65,7 +64,6 @@ export function updateHPBar(enemyState) {
         }
       };
       victoryOverlay.addEventListener('click', (e) => { e.stopPropagation(); proceed(); }, { once: true });
-      retryButton.addEventListener('click', (e) => { e.stopPropagation(); proceed(); }, { once: true });
     }, 200);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused retry button from victory overlay
- eliminate related styles and JS logic

## Testing
- `node --check ui.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897caac4ad48330aad6e85483a242b5