### PR TITLE
fix ammo not updating when adding balls

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,6 +75,9 @@ const randomEvents = [
         label: '拾っちゃお🎀',
         apply() {
           playerState.ownedBalls.push('normal');
+          playerState.ammo = playerState.ownedBalls.slice();
+          updateAmmo();
+          updateCurrentBall(firePoint);
         },
         result: 'ノーマルボールゲットだよ☆'
       },
@@ -331,6 +334,9 @@ window.addEventListener('DOMContentLoaded', () => {
       if (!playerState.ballLevels[type]) {
         playerState.ballLevels[type] = 1;
       }
+      playerState.ammo = playerState.ownedBalls.slice();
+      updateAmmo();
+      updateCurrentBall(firePoint);
       rewardOverlay.style.display = 'none';
       triggerRandomEvent();
     });

--- a/ui.js
+++ b/ui.js
@@ -1,6 +1,7 @@
 import { playerState } from './player.js';
 import { handleShoot } from './main.js';
 import { healBallPath } from './constants.js';
+import { firePoint } from './engine.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -182,10 +183,12 @@ export function showShopOverlay(onDone) {
     } else {
       return;
     }
+    playerState.ammo = playerState.ownedBalls.slice();
     localStorage.setItem('coins', playerState.coins);
     shopOptions.removeEventListener('click', handleClick);
     shopOverlay.style.display = 'none';
     updateAmmo();
+    updateCurrentBall(firePoint);
     updateCoins();
     onDone && onDone();
   };


### PR DESCRIPTION
## Summary
- sync owned balls with ammo when acquiring or selling balls
- refresh current ball display after ammo changes

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d04f4e1c8330ae7e9729b2d5139b