### PR TITLE
ショットキューで弾順を固定してUIに表示

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -1,6 +1,6 @@
 import { playerState } from './player.js';
 import { firePoint, generatePegs } from './engine.js';
-import { updateAmmo, updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, updateProgress, selectNextBall as uiSelectNextBall, updateAttackCountdown } from './ui.js';
+import { updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, updateProgress, selectNextBall as uiSelectNextBall, updateAttackCountdown } from './ui.js';
 
 export const enemyState = {
   stage: 1,
@@ -30,8 +30,8 @@ export function startStage() {
   playerState.currentBalls = [];
   playerState.currentShotType = null;
   playerState.ammo = playerState.ownedBalls.slice();
+  playerState.shotQueue = playerState.ammo.slice();
   enemyState.updateHPBar();
-  updateAmmo();
   uiSelectNextBall(firePoint);
   enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
   document.getElementById('stage-value').textContent = enemyState.stage;

--- a/engine.js
+++ b/engine.js
@@ -323,7 +323,6 @@ export function setupCollisionHandler() {
           } else {
             updateAttackCountdown(enemyState);
           }
-          enemyState.selectNextBall();
         }
       }
     });

--- a/main.js
+++ b/main.js
@@ -76,8 +76,8 @@ const randomEvents = [
         apply() {
           playerState.ownedBalls.push('normal');
           playerState.ammo = playerState.ownedBalls.slice();
-          updateAmmo();
-          updateCurrentBall(firePoint);
+          playerState.shotQueue = playerState.ammo.slice();
+          enemyState.selectNextBall();
         },
         result: 'ノーマルボールゲットだよ☆'
       },
@@ -229,8 +229,8 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.reloading = true;
     setTimeout(() => {
       playerState.ammo = playerState.ownedBalls.slice();
+      playerState.shotQueue = playerState.ammo.slice();
       reloadOverlay.style.display = 'none';
-      updateAmmo();
       enemyState.selectNextBall();
       playerState.reloading = false;
     }, 1000);
@@ -302,13 +302,13 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
     playerState.playerHP = playerState.playerMaxHP;
     playerState.ammo = playerState.ownedBalls.slice();
+    playerState.shotQueue = playerState.ammo.slice();
     playerState.currentBalls = [];
     playerState.currentShotType = null;
     playerState.nextBall = null;
     playerState.reloading = false;
     updatePlayerHP();
-    updateAmmo();
-    updateCurrentBall(firePoint);
+    enemyState.selectNextBall();
     updateProgress(enemyState);
     document.getElementById('stage-value').textContent = enemyState.stage;
     playerState.coins = 0;
@@ -335,8 +335,8 @@ window.addEventListener('DOMContentLoaded', () => {
         playerState.ballLevels[type] = 1;
       }
       playerState.ammo = playerState.ownedBalls.slice();
-      updateAmmo();
-      updateCurrentBall(firePoint);
+      playerState.shotQueue = playerState.ammo.slice();
+      enemyState.selectNextBall();
       rewardOverlay.style.display = 'none';
       triggerRandomEvent();
     });
@@ -353,13 +353,13 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
     playerState.playerHP = playerState.playerMaxHP;
     playerState.ammo = playerState.ownedBalls.slice();
+    playerState.shotQueue = playerState.ammo.slice();
     playerState.currentBalls = [];
     playerState.currentShotType = null;
     playerState.nextBall = null;
     playerState.reloading = false;
     updatePlayerHP();
-    updateAmmo();
-    updateCurrentBall(firePoint);
+    enemyState.selectNextBall();
     updateProgress(enemyState);
     playerState.coins = 0;
     localStorage.setItem('coins', playerState.coins);
@@ -403,7 +403,7 @@ window.addEventListener('DOMContentLoaded', () => {
     shootBall(angle, type);
     clearTimeout(aimTimer);
     clearSimulatedPath();
-    updateAmmo();
+    enemyState.selectNextBall();
   };
 
   aimSvg.addEventListener('click', handleShoot);

--- a/player.js
+++ b/player.js
@@ -4,6 +4,7 @@ export const playerState = {
   playerHP: 100,
   playerMaxHP: 100,
   ammo: [],
+  shotQueue: [],
   ownedBalls: [],
   ballLevels: { normal: 1 },
   nextBall: null,

--- a/style.css
+++ b/style.css
@@ -146,6 +146,18 @@ html, body {
   padding: 0 3px;
   line-height: 1;
 }
+
+.queue-number {
+  position: absolute;
+  bottom: -6px;
+  left: -6px;
+  background: #fff;
+  color: #000;
+  font-size: 10px;
+  border-radius: 50%;
+  padding: 0 3px;
+  line-height: 1;
+}
 .hp-container {
   display: flex;
   flex-direction: column;

--- a/ui.js
+++ b/ui.js
@@ -81,7 +81,7 @@ export function updatePlayerHP() {
 
 export function updateAmmo() {
   ammoValue.innerHTML = '';
-  playerState.ammo.forEach(type => {
+  playerState.shotQueue.forEach((type, index) => {
     const icon = document.createElement('span');
     icon.className = 'ammo-ball';
     if (type === 'normal') {
@@ -102,6 +102,13 @@ export function updateAmmo() {
       badge.className = 'level-badge';
       badge.textContent = `+${lvl - 1}`;
       icon.appendChild(badge);
+    }
+    const num = document.createElement('span');
+    num.className = 'queue-number';
+    num.textContent = index + 1;
+    icon.appendChild(num);
+    if (index === 0) {
+      icon.style.outline = '2px solid yellow';
     }
     ammoValue.appendChild(icon);
   });
@@ -184,11 +191,11 @@ export function showShopOverlay(onDone) {
       return;
     }
     playerState.ammo = playerState.ownedBalls.slice();
+    playerState.shotQueue = playerState.ammo.slice();
     localStorage.setItem('coins', playerState.coins);
     shopOptions.removeEventListener('click', handleClick);
     shopOverlay.style.display = 'none';
-    updateAmmo();
-    updateCurrentBall(firePoint);
+    selectNextBall(firePoint);
     updateCoins();
     onDone && onDone();
   };
@@ -242,13 +249,13 @@ export function updateCurrentBall(firePoint) {
 }
 
 export function selectNextBall(firePoint) {
-  if (playerState.ammo.length > 0) {
-    const idx = Math.floor(Math.random() * playerState.ammo.length);
-    playerState.nextBall = playerState.ammo[idx];
+  if (playerState.shotQueue.length > 0) {
+    playerState.nextBall = playerState.shotQueue.shift();
   } else {
     playerState.nextBall = null;
   }
   updateCurrentBall(firePoint);
+  updateAmmo();
 }
 
 export function flashEnemyDamage(enemyState) {


### PR DESCRIPTION
## Summary
- プレイヤー状態に shotQueue を追加してステージ開始やリロード時に弾を並べ直す
- selectNextBall / handleShoot を修正してキュー先頭から弾を取得
- updateAmmo を shotQueue 表示に対応し、次に撃つ弾をハイライト

## Testing
- `npm test` (package.json 不在で失敗)


------
https://chatgpt.com/codex/tasks/task_e_6898cf25ab7c8330b65f2b4800a52921