### PR TITLE
Disable pointer events on non-interactive overlays

### DIFF
--- a/style.css
+++ b/style.css
@@ -49,6 +49,7 @@ html, body {
   border: 2px solid #ff69b4;
   border-radius: 8px;
   z-index: 10;
+  pointer-events: none;
 }
 #player-hp-text {
   font-size: 14px;
@@ -558,6 +559,7 @@ canvas {
   top: 16px;
   left: auto;
   z-index: 10;
+  pointer-events: none;
   list-style: none;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- avoid accidental clicks on player HP display
- stop progress indicator from catching pointer events

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d202426c8330b78fa3024a40bec4