### PR TITLE
feat: ペネトレーションボール追加

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -219,6 +219,8 @@ export function shootBall(angle, type) {
               ? healBallPath
               : type === 'big'
               ? './image/big_ball.png'
+              : type === 'penetration'
+              ? './image/penetration_ball.png'
               : './image/normal_ball.png',
           xScale: scale,
           yScale: scale

--- a/index.html
+++ b/index.html
@@ -77,6 +77,11 @@
           <div class="reward-name">ビッグボール</div>
           <div class="reward-desc">弾がでかくなるよ☆</div>
         </button>
+        <button class="reward-button" data-type="penetration">
+          <img src="image/penetration_ball.png" alt="ペネトレーションボール">
+          <div class="reward-name">ペネトレーションボール</div>
+          <div class="reward-desc">敵を貫通するよ♡</div>
+        </button>
       </div>
     </div>
     <div id="event-overlay">

--- a/main.js
+++ b/main.js
@@ -8,7 +8,8 @@ const ballImageMap = {
   normal: './image/normal_ball.png',
   split: './image/split_ball.png',
   heal: healBallPath,
-  big: './image/big_ball.png'
+  big: './image/big_ball.png',
+  penetration: './image/penetration_ball.png'
 };
 
 const randomEvents = [

--- a/ui.js
+++ b/ui.js
@@ -92,6 +92,8 @@ export function updateAmmo() {
       icon.style.backgroundImage = `url("${healBallPath}")`;
     } else if (type === 'big') {
       icon.style.backgroundImage = 'url("./image/big_ball.png")';
+    } else if (type === 'penetration') {
+      icon.style.backgroundImage = 'url("./image/penetration_ball.png")';
     }
     icon.style.backgroundSize = 'cover';
     icon.style.backgroundColor = 'transparent';
@@ -126,14 +128,16 @@ const shopData = {
   normal: { label: 'ノーマル', buy: 5, sell: 5, upgrade: 8 },
   split: { label: 'スプリット', buy: 10, sell: 10, upgrade: 15 },
   heal: { label: 'ヒール', buy: 10, sell: 10, upgrade: 15 },
-  big: { label: 'ビッグ', buy: 10, sell: 10, upgrade: 15 }
+  big: { label: 'ビッグ', buy: 10, sell: 10, upgrade: 15 },
+  penetration: { label: 'ペネトレーション', buy: 10, sell: 10, upgrade: 15 }
 };
 
 const shopImageMap = {
   normal: './image/normal_ball.png',
   split: './image/split_ball.png',
   heal: healBallPath,
-  big: './image/big_ball.png'
+  big: './image/big_ball.png',
+  penetration: './image/penetration_ball.png'
 };
 
 export function showShopOverlay(onDone) {
@@ -227,7 +231,8 @@ export function updateCurrentBall(firePoint) {
     normal: 'normal_ball.png',
     split: 'split_ball.png',
     big: 'big_ball.png',
-    heal: 'recovery_ball.png'
+    heal: 'recovery_ball.png',
+    penetration: 'penetration_ball.png'
   };
   const img = imageMap[playerState.nextBall];
   if (img) {


### PR DESCRIPTION
## Summary
- ペネトレーションボールのボタン＆画像対応
- ボール一覧とショップにペネトレーションを追加
- 発射時やアイコンでペネトレーションの画像表示OK

## Testing
- `npm test` (package.json がなくて失敗😭)

------
https://chatgpt.com/codex/tasks/task_e_6898d2d253b08330bff1a85868ce33df