### PR TITLE
Add bamboo icon credit

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
       <p><a href="https://www.flaticon.com/free-icons/heart" title="heart icons">Heart icons created by Fathema Khanom - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/bowling" title="bowling icons">Bowling icons created by smashingstocks - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/pet" title="pet icons">Pet icons created by Ylivdesign - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/bamboo" title="bamboo icons">Bamboo icons created by Victoruler - Flaticon</a></p>
       <button id="credit-close">閉じる</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add bamboo icons credit to the credit overlay

## Testing
- `npm test` *(fails: could not read package.json)*
- `xdg-open index.html` *(fails: command not found)*
- `python3 -m http.server 8000` and `curl -s http://localhost:8000/index.html | grep -n "Bamboo" -n`


------
https://chatgpt.com/codex/tasks/task_e_6898d53c18088330b5b3f8e32f3adc7d