### PR TITLE
ランダム射出キューにシャッフルを導入

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -1,6 +1,7 @@
 import { playerState } from './player.js';
 import { firePoint, generatePegs } from './engine.js';
 import { updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, updateProgress, selectNextBall as uiSelectNextBall, updateAttackCountdown } from './ui.js';
+import { shuffle } from './utils.js';
 
 export const enemyState = {
   stage: 1,
@@ -29,8 +30,8 @@ export function startStage() {
   enemyState.pendingDamage = 0;
   playerState.currentBalls = [];
   playerState.currentShotType = null;
-  playerState.ammo = playerState.ownedBalls.slice();
-  playerState.shotQueue = playerState.ammo.slice();
+    playerState.ammo = playerState.ownedBalls.slice();
+    playerState.shotQueue = shuffle(playerState.ammo.slice());
   enemyState.updateHPBar();
   uiSelectNextBall(firePoint);
   enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
 import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay, updateCoins } from './ui.js';
 import { healBallPath } from './constants.js';
+import { shuffle } from './utils.js';
 
 const ballImageMap = {
   normal: './image/normal_ball.png',
@@ -75,10 +76,10 @@ const randomEvents = [
       {
         label: '拾っちゃお🎀',
         apply() {
-          playerState.ownedBalls.push('normal');
-          playerState.ammo = playerState.ownedBalls.slice();
-          playerState.shotQueue = playerState.ammo.slice();
-          enemyState.selectNextBall();
+            playerState.ownedBalls.push('normal');
+            playerState.ammo = playerState.ownedBalls.slice();
+            playerState.shotQueue = shuffle(playerState.ammo.slice());
+            enemyState.selectNextBall();
         },
         result: 'ノーマルボールゲットだよ☆'
       },
@@ -230,7 +231,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.reloading = true;
     setTimeout(() => {
       playerState.ammo = playerState.ownedBalls.slice();
-      playerState.shotQueue = playerState.ammo.slice();
+      playerState.shotQueue = shuffle(playerState.ammo.slice());
       reloadOverlay.style.display = 'none';
       enemyState.selectNextBall();
       playerState.reloading = false;
@@ -303,7 +304,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
     playerState.playerHP = playerState.playerMaxHP;
     playerState.ammo = playerState.ownedBalls.slice();
-    playerState.shotQueue = playerState.ammo.slice();
+    playerState.shotQueue = shuffle(playerState.ammo.slice());
     playerState.currentBalls = [];
     playerState.currentShotType = null;
     playerState.nextBall = null;
@@ -336,7 +337,7 @@ window.addEventListener('DOMContentLoaded', () => {
         playerState.ballLevels[type] = 1;
       }
       playerState.ammo = playerState.ownedBalls.slice();
-      playerState.shotQueue = playerState.ammo.slice();
+      playerState.shotQueue = shuffle(playerState.ammo.slice());
       enemyState.selectNextBall();
       rewardOverlay.style.display = 'none';
       triggerRandomEvent();
@@ -354,7 +355,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
     playerState.playerHP = playerState.playerMaxHP;
     playerState.ammo = playerState.ownedBalls.slice();
-    playerState.shotQueue = playerState.ammo.slice();
+    playerState.shotQueue = shuffle(playerState.ammo.slice());
     playerState.currentBalls = [];
     playerState.currentShotType = null;
     playerState.nextBall = null;

--- a/ui.js
+++ b/ui.js
@@ -2,6 +2,7 @@ import { playerState } from './player.js';
 import { handleShoot } from './main.js';
 import { healBallPath } from './constants.js';
 import { firePoint } from './engine.js';
+import { shuffle } from './utils.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -195,7 +196,7 @@ export function showShopOverlay(onDone) {
       return;
     }
     playerState.ammo = playerState.ownedBalls.slice();
-    playerState.shotQueue = playerState.ammo.slice();
+    playerState.shotQueue = shuffle(playerState.ammo.slice());
     localStorage.setItem('coins', playerState.coins);
     shopOptions.removeEventListener('click', handleClick);
     shopOverlay.style.display = 'none';

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,7 @@
+export function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}


### PR DESCRIPTION
## Summary
- utils.js に Fisher-Yates 方式の shuffle 関数を追加
- ステージ開始やリロード、ショップ更新などで弾キューをシャッフル

## Testing
- `npm test` (package.json がなく失敗)


------
https://chatgpt.com/codex/tasks/task_e_6898db6656cc8330a878d1f3267144b4