### PR TITLE
feat: remove border from penetration ball

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -240,6 +240,11 @@ export function updateCurrentBall(firePoint) {
     currentBallEl.style.backgroundImage = `url("./image/${img}")`;
     currentBallEl.style.backgroundSize = 'cover';
     currentBallEl.style.backgroundColor = 'transparent';
+    if (playerState.nextBall === 'penetration') {
+      currentBallEl.style.border = 'none';
+    } else {
+      currentBallEl.style.border = '2px solid #ff69b4';
+    }
   } else {
     currentBallEl.style.backgroundImage = '';
     currentBallEl.style.backgroundColor = '#00bfff';


### PR DESCRIPTION
## Summary
- toggle current ball border so penetration type has none

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e156d08c8330b6c4659b7bdf9492