### PR TITLE
fix: align penetration ball sprite and orientation

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -44,6 +44,10 @@ export function initEngine() {
   Events.on(engine, 'beforeUpdate', () => {
     playerState.currentBalls.forEach(ball => {
       ball.prevVelocity = { x: ball.velocity.x, y: ball.velocity.y };
+      if (ball.ballType === 'penetration') {
+        const angle = Math.atan2(ball.velocity.y, ball.velocity.x) + Math.PI / 2;
+        Body.setAngle(ball, angle);
+      }
     });
   });
 
@@ -224,11 +228,14 @@ export function shootBall(angle, type) {
         sprite: {
           texture: './image/penetration_ball.png',
           xScale: scale,
-          yScale: scale
+          yScale: scale,
+          xOffset: 0.5,
+          yOffset: 1
         }
       }
     };
     const ball = Bodies.circle(firePoint.x, firePoint.y, radius, options);
+    Body.setAngle(ball, Math.PI / 2);
     ball.damageMultiplier = dmgMul;
     ball.ballType = 'penetration';
     Body.setVelocity(ball, { x: Math.cos(angle) * power, y: Math.sin(angle) * power });


### PR DESCRIPTION
## Summary
- ensure penetration ball sprite origin aligns with tip using x/y offsets
- set initial orientation and update rotation by velocity

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68996406ae0483308317ba20078969cf