### PR TITLE
fix: handle shooting without prepared ball

### DIFF
--- a/main.js
+++ b/main.js
@@ -390,6 +390,10 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   handleShoot = function handleShoot(e) {
+    if (!playerState.nextBall) {
+      enemyState.selectNextBall();
+      if (!playerState.nextBall) return;
+    }
     if (playerState.currentBalls.length > 0 || enemyState.gameOver || playerState.reloading || isAnyOverlayVisible()) return;
     if (playerState.ammo.length <= 0) {
       startReload();


### PR DESCRIPTION
## Summary
- avoid shooting when no ball is prepared by selecting next ball or aborting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b26a6352883309adb672141601f9f