### PR TITLE
Reset ghost engine on path clear

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -155,7 +155,7 @@ export function generatePegs(count) {
 
 export function drawSimulatedPath(angle, speed) {
   while (aimSvg.firstChild) aimSvg.removeChild(aimSvg.firstChild);
-  if (!ghostEngine) {
+  if (!ghostEngine || !ghostBall) {
     createGhostEngine();
   }
   if (!ghostEngine.world.bodies.includes(ghostBall)) {
@@ -185,6 +185,8 @@ export function clearSimulatedPath() {
     World.clear(ghostEngine.world, false);
     Engine.clear(ghostEngine);
   }
+  ghostEngine = null;
+  ghostBall = null;
 }
 
 export function shootBall(angle, type) {


### PR DESCRIPTION
## Summary
- reset ghost engine and ball to null when clearing simulated path
- recreate ghost engine and ball when drawing path if missing

## Testing
- `node --check engine.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b275cb29083308fe5dd64dd53cd60