### PR TITLE
feat: auto reload when balls cleared

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -372,6 +372,7 @@ export function setupCollisionHandler() {
           } else {
             updateAttackCountdown(enemyState);
           }
+          document.dispatchEvent(new Event('ballsCleared'));
         }
       }
     });

--- a/main.js
+++ b/main.js
@@ -238,6 +238,12 @@ window.addEventListener('DOMContentLoaded', () => {
     }, 1000);
   };
 
+  document.addEventListener('ballsCleared', () => {
+    if (playerState.ammo.length === 0 && !playerState.reloading) {
+      startReload();
+    }
+  });
+
   startButton.addEventListener('click', (e) => {
     e.stopPropagation();
     enemyState.stage = 1;


### PR DESCRIPTION
## Summary
- dispatch `ballsCleared` when last ball touches bottom sensor
- start reload automatically on `ballsCleared` if out of ammo

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check engine.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689b33fd1e148330bd4e4080daf3d946