### PR TITLE
Add settings overlay to main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <button id="start-button" class="menu-option">スタート</button>
         <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
         <button id="reset-progress" class="menu-option">進捗リセット</button>
+        <button id="settings-button" class="menu-option">設定</button>
       </div>
       <div id="upgrade-buttons">
         <div id="xp-display">経験値: <span id="xp-value">0</span></div>
@@ -104,6 +105,10 @@
       <button id="game-over-retry-button">リトライ</button>
     </div>
     <div id="reload-overlay">リロード中…</div>
+    <div id="settings-overlay">
+      <h2 id="settings-title">設定</h2>
+      <button id="settings-close">閉じる</button>
+    </div>
     <div id="credit-overlay">
       <p>Bomb icon by Freepik - Flaticon</p>
       <p><a href="https://www.flaticon.com/free-icons/coin" title="coin icons">Coin icons created by popo2021 - Flaticon</a></p>

--- a/main.js
+++ b/main.js
@@ -132,6 +132,15 @@ window.addEventListener('DOMContentLoaded', () => {
     const creditBtn = document.getElementById('credit-button');
     const creditOverlay = document.getElementById('credit-overlay');
     const creditClose = document.getElementById('credit-close');
+    const settingsButton = document.getElementById('settings-button');
+    const settingsOverlay = document.getElementById('settings-overlay');
+    const settingsClose = document.getElementById('settings-close');
+
+    if (document.documentElement.lang === 'en') {
+      settingsButton.textContent = 'Settings';
+      document.getElementById('settings-title').textContent = 'Settings';
+      settingsClose.textContent = 'Close';
+    }
 
   const overlays = [
     menuOverlay,
@@ -142,7 +151,8 @@ window.addEventListener('DOMContentLoaded', () => {
     reloadOverlay,
       victoryOverlay,
       shopOverlay,
-      creditOverlay
+      creditOverlay,
+      settingsOverlay
     ];
 
   const isAnyOverlayVisible = () =>
@@ -332,6 +342,16 @@ window.addEventListener('DOMContentLoaded', () => {
     creditClose.addEventListener('click', (e) => {
       e.stopPropagation();
       hideOverlay(creditOverlay);
+    });
+
+    settingsButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      showOverlay(settingsOverlay);
+    });
+
+    settingsClose.addEventListener('click', (e) => {
+      e.stopPropagation();
+      hideOverlay(settingsOverlay);
     });
 
   rewardButtons.forEach(btn => {

--- a/style.css
+++ b/style.css
@@ -763,12 +763,43 @@ canvas {
     transition: opacity .3s;
   }
 
+  #settings-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.9);
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 60;
+    opacity: 0;
+    transition: opacity .3s;
+  }
+
   #credit-overlay.show {
     display: flex;
     opacity: 1;
   }
 
+  #settings-overlay.show {
+    display: flex;
+    opacity: 1;
+  }
+
   #credit-overlay button {
+    margin-top: 20px;
+    padding: 10px 20px;
+    border: 2px solid #ff69b4;
+    background: #fff;
+    color: #ff1493;
+    cursor: pointer;
+    border-radius: 8px;
+  }
+
+  #settings-overlay button {
     margin-top: 20px;
     padding: 10px 20px;
     border: 2px solid #ff69b4;


### PR DESCRIPTION
## Summary
- add Settings button to main menu with English label support
- implement settings overlay and toggle logic

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d76745b208330a77246a49fb27eb6