### PR TITLE
Add language selection and i18n support

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,38 @@
+export const translations = {
+  ja: {
+    startButton: 'スタート',
+    upgradeMenuButton: 'アップグレード',
+    resetButton: '進捗リセット',
+    settingsButton: '設定',
+    xpDisplay: '経験値: ',
+    upgradeHp: 'HPアップ(+10) 10XP',
+    upgradeAtk: '攻撃アップ(+10%) 10XP',
+    upgradeBack: '戻る',
+    creditButton: 'クレジット',
+    settingsTitle: '設定',
+    settingsClose: '閉じる',
+    languageLabel: '言語',
+    xpContinueButton: 'メニューへ',
+    gameOverRetryButton: 'リトライ',
+    ammoText: '弾: ',
+    stageText: 'ステージ: '
+  },
+  en: {
+    startButton: 'Start',
+    upgradeMenuButton: 'Upgrade',
+    resetButton: 'Reset Progress',
+    settingsButton: 'Settings',
+    xpDisplay: 'XP: ',
+    upgradeHp: 'HP Up (+10) 10XP',
+    upgradeAtk: 'ATK Up (+10%) 10XP',
+    upgradeBack: 'Back',
+    creditButton: 'Credits',
+    settingsTitle: 'Settings',
+    settingsClose: 'Close',
+    languageLabel: 'Language',
+    xpContinueButton: 'Menu',
+    gameOverRetryButton: 'Retry',
+    ammoText: 'Ammo: ',
+    stageText: 'Stage: '
+  }
+};

--- a/index.html
+++ b/index.html
@@ -105,8 +105,13 @@
       <button id="game-over-retry-button">リトライ</button>
     </div>
     <div id="reload-overlay">リロード中…</div>
-    <div id="settings-overlay">
+  <div id="settings-overlay">
       <h2 id="settings-title">設定</h2>
+      <label for="language-select" id="language-label">言語</label>
+      <select id="language-select">
+        <option value="ja">日本語</option>
+        <option value="en">English</option>
+      </select>
       <button id="settings-close">閉じる</button>
     </div>
     <div id="credit-overlay">

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ import { enemyState, startStage } from './enemy.js';
 import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay, updateCoins } from './ui.js';
 import { healBallPath } from './constants.js';
 import { shuffle } from './utils.js';
+import { translations } from './i18n.js';
 
 const ballImageMap = {
   normal: './image/balls/normal_ball.png',
@@ -97,6 +98,38 @@ const randomEvents = [
 
 export let handleShoot;
 
+export function setLanguage(lang) {
+  const t = translations[lang];
+  if (!t) return;
+  document.documentElement.lang = lang;
+  const map = {
+    'start-button': 'startButton',
+    'upgrade-menu-button': 'upgradeMenuButton',
+    'reset-progress': 'resetButton',
+    'settings-button': 'settingsButton',
+    'upgrade-hp': 'upgradeHp',
+    'upgrade-atk': 'upgradeAtk',
+    'upgrade-back': 'upgradeBack',
+    'credit-button': 'creditButton',
+    'settings-title': 'settingsTitle',
+    'settings-close': 'settingsClose',
+    'language-label': 'languageLabel',
+    'xp-continue-button': 'xpContinueButton',
+    'game-over-retry-button': 'gameOverRetryButton'
+  };
+  Object.entries(map).forEach(([id, key]) => {
+    const el = document.getElementById(id);
+    if (el && t[key]) el.textContent = t[key];
+  });
+  const xpDisplay = document.getElementById('xp-display');
+  if (xpDisplay && t.xpDisplay) xpDisplay.childNodes[0].textContent = t.xpDisplay;
+  const ammoText = document.getElementById('ammo-text');
+  if (ammoText && t.ammoText) ammoText.childNodes[0].textContent = t.ammoText;
+  const stageText = document.getElementById('stage-text');
+  if (stageText && t.stageText) stageText.childNodes[0].textContent = t.stageText;
+  localStorage.setItem('language', lang);
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   initEngine();
   setupCollisionHandler();
@@ -135,12 +168,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const settingsButton = document.getElementById('settings-button');
     const settingsOverlay = document.getElementById('settings-overlay');
     const settingsClose = document.getElementById('settings-close');
-
-    if (document.documentElement.lang === 'en') {
-      settingsButton.textContent = 'Settings';
-      document.getElementById('settings-title').textContent = 'Settings';
-      settingsClose.textContent = 'Close';
-    }
+    const languageSelect = document.getElementById('language-select');
 
   const overlays = [
     menuOverlay,
@@ -154,6 +182,13 @@ window.addEventListener('DOMContentLoaded', () => {
       creditOverlay,
       settingsOverlay
     ];
+
+  const savedLang = localStorage.getItem('language') || document.documentElement.lang || 'ja';
+  setLanguage(savedLang);
+  if (languageSelect) {
+    languageSelect.value = savedLang;
+    languageSelect.addEventListener('change', (e) => setLanguage(e.target.value));
+  }
 
   const isAnyOverlayVisible = () =>
     overlays.some(o => window.getComputedStyle(o).display !== 'none');


### PR DESCRIPTION
## Summary
- centralize UI strings in translations table
- add setLanguage utility and language selector
- persist chosen language in localStorage and update `<html>` lang

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check i18n.js main.js`

------
https://chatgpt.com/codex/tasks/task_e_689d7792d5d08330a059aee075fe2bdc