### PR TITLE
feat: add i18n support

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -47,9 +47,7 @@ export const enemyState = {
   pendingDamage: 0,
   attackCountdown: 0,
   gameOver: false,
-  progressSteps: [
-    'ステージ1', 'ランダムイベント', 'ステージ2', 'ランダムイベント', 'ステージ3', 'ランダムイベント', 'ステージ4', 'ランダムイベント', 'ステージ5'
-  ],
+  progressSteps: [1, 'event', 2, 'event', 3, 'event', 4, 'event', 5],
   progressIndex: 0,
   lastVariantIndex: -1,
   normalImage: defaultEnemy.normalImage,

--- a/i18n.js
+++ b/i18n.js
@@ -1,38 +1,262 @@
 export const translations = {
   ja: {
-    startButton: 'スタート',
-    upgradeMenuButton: 'アップグレード',
-    resetButton: '進捗リセット',
-    settingsButton: '設定',
-    xpDisplay: '経験値: ',
-    upgradeHp: 'HPアップ(+10) 10XP',
-    upgradeAtk: '攻撃アップ(+10%) 10XP',
-    upgradeBack: '戻る',
-    creditButton: 'クレジット',
-    settingsTitle: '設定',
-    settingsClose: '閉じる',
-    languageLabel: '言語',
-    xpContinueButton: 'メニューへ',
-    gameOverRetryButton: 'リトライ',
-    ammoText: '弾: ',
-    stageText: 'ステージ: '
+    menu: {
+      title: 'Peggy Girls',
+      start: 'スタート',
+      upgrade: 'アップグレード',
+      reset: '進捗リセット',
+      settings: '設定',
+      credit: 'クレジット'
+    },
+    upgrade: {
+      xp: '経験値: ',
+      hp: 'HPアップ(+10) 10XP',
+      atk: '攻撃アップ(+10%) 10XP',
+      back: '戻る'
+    },
+    hud: {
+      hp: 'HP: ',
+      ammo: '弾: ',
+      stage: 'ステージ: '
+    },
+    balls: {
+      normal: { name: 'ノーマル', full: 'ノーマルボール' },
+      split: { name: 'スプリット', full: 'スプリットボール' },
+      heal: { name: 'ヒール', full: 'ヒールボール' },
+      big: { name: 'ビッグ', full: 'ビッグボール' },
+      penetration: { name: 'ペネトレーション', full: 'ペネトレーションボール' }
+    },
+    reward: {
+      title: 'リザルト',
+      coinSuffix: 'コインGET',
+      message: '報酬ボールを選んでね',
+      options: {
+        split: { desc: '弾が2つに分裂するよ♪' },
+        heal: { desc: '当たるとHP回復するよ☆' },
+        big: { desc: '弾がでかくなるよ☆' },
+        penetration: { desc: '敵を貫通するよ♡' }
+      }
+    },
+    event: { title: 'ランダムイベント発生☆' },
+    shop: {
+      title: 'ショップだよ☆',
+      close: 'やめる',
+      buy: '購入',
+      sell: '削除',
+      upgrade: '強化'
+    },
+    xp: { title: '経験値GET! +', continue: 'メニューへ' },
+    gameOver: { retry: 'リトライ' },
+    reload: { text: 'リロード中…' },
+    settings: {
+      title: '設定',
+      language: '言語',
+      options: { ja: '日本語', en: 'English' },
+      close: '閉じる'
+    },
+    credit: { close: '閉じる' },
+    progress: { randomEvent: 'ランダムイベント' },
+    events: {
+      spring: {
+        text: 'キラキラの泉を発見したよ☆',
+        choices: {
+          drink: 'ゴクゴク飲む💖',
+          skip: 'やめとく〜'
+        },
+        results: {
+          drink: 'HPが20回復したよ💕',
+          skip: '何も変わらなかったよ〜'
+        }
+      },
+      powerStone: {
+        text: '怪しいパワーストーン✨どのボールを強化する？',
+        choiceLabel: '{type}ボール強化する〜',
+        result: '{type}ボールがパワーアップしたよ✨',
+        passLabel: 'やっぱパス',
+        passResult: '強化しなかったよ〜'
+      },
+      trap: {
+        text: 'トゲトゲの罠があるっぽい…',
+        choices: {
+          avoid: 'そっと避ける✨',
+          step: '踏んでみる⁉️'
+        },
+        results: {
+          avoid: '上手く避けたよ♪',
+          step: 'イタタ…HPが20減っちゃった💦'
+        }
+      },
+      foundBall: {
+        text: '道端にノーマルボールが落ちてた！',
+        choices: {
+          take: '拾っちゃお🎀',
+          skip: '今はいらないかも'
+        },
+        results: {
+          take: 'ノーマルボールゲットだよ☆',
+          skip: 'スルーしたよ〜'
+        }
+      }
+    },
+    history: {
+      title: 'バージョン履歴',
+      v1_4: 'v1.4 (2025-08-10) 敵画像ファイル名の整理＆参照更新',
+      v1_3: 'v1.3 (2025-08-09) 爆弾衝突のバグ修正＆コインアイコンクレジット追加',
+      v1_2: 'v1.2 (2025-08-06) バージョン履歴を更新',
+      v1_1: 'v1.1 (2025-08-05) メニュー画面＆スタートボタン、弾数アイコンと特殊弾選択、ステージ進行と敵HPスケール、リロード演出、ステージ5で経験値＆スキル強化を追加',
+      v1_0: 'v1.0 (2025-08-05) ステージ5クリアで経験値獲得＆スキル強化追加',
+      v0_9_2: 'v0.9.2 (2025-08-05) プレイヤーHP0で敗北オーバーレイ表示',
+      v0_9_1: 'v0.9.1 (2025-08-05) 初期ボール数を3に設定',
+      v0_9: 'v0.9 (2025-08-05) 弾数制限とリロードを実装',
+      v0_8: 'v0.8 (2025-08-05) 爆弾ペグ追加',
+      v0_7: 'v0.7 (2025-08-04) 敗北オーバーレイとランダム画像',
+      v0_6: 'v0.6 (2025-08-04) ペグのランダム化と黄色ペグのダブルダメージ',
+      v0_5: 'v0.5 (2025-08-04) 勝利画像とリトライボタン',
+      v0_4: 'v0.4 (2025-08-04) 累積ダメージ表示、着地時にダメージ確定',
+      v0_3: 'v0.3 (2025-08-04) ボール落下ダメージとエフェクト',
+      v0_2: 'v0.2 (2025-08-04) 敵ダメージ時に画像を一瞬切り替え',
+      v0_1: 'v0.1 (2025-08-03) 初期リリース'
+    },
+    common: { ok: 'OK' }
   },
   en: {
-    startButton: 'Start',
-    upgradeMenuButton: 'Upgrade',
-    resetButton: 'Reset Progress',
-    settingsButton: 'Settings',
-    xpDisplay: 'XP: ',
-    upgradeHp: 'HP Up (+10) 10XP',
-    upgradeAtk: 'ATK Up (+10%) 10XP',
-    upgradeBack: 'Back',
-    creditButton: 'Credits',
-    settingsTitle: 'Settings',
-    settingsClose: 'Close',
-    languageLabel: 'Language',
-    xpContinueButton: 'Menu',
-    gameOverRetryButton: 'Retry',
-    ammoText: 'Ammo: ',
-    stageText: 'Stage: '
+    menu: {
+      title: 'Peggy Girls',
+      start: 'Start',
+      upgrade: 'Upgrade',
+      reset: 'Reset Progress',
+      settings: 'Settings',
+      credit: 'Credits'
+    },
+    upgrade: {
+      xp: 'XP: ',
+      hp: 'HP Up (+10) 10XP',
+      atk: 'ATK Up (+10%) 10XP',
+      back: 'Back'
+    },
+    hud: {
+      hp: 'HP: ',
+      ammo: 'Ammo: ',
+      stage: 'Stage: '
+    },
+    balls: {
+      normal: { name: 'Normal', full: 'Normal Ball' },
+      split: { name: 'Split', full: 'Split Ball' },
+      heal: { name: 'Heal', full: 'Heal Ball' },
+      big: { name: 'Big', full: 'Big Ball' },
+      penetration: { name: 'Penetration', full: 'Penetration Ball' }
+    },
+    reward: {
+      title: 'Result',
+      coinSuffix: 'Coins',
+      message: 'Choose your reward ball',
+      options: {
+        split: { desc: 'Splits into two♪' },
+        heal: { desc: 'Restores HP on hit☆' },
+        big: { desc: 'Becomes bigger☆' },
+        penetration: { desc: 'Pierces enemies♡' }
+      }
+    },
+    event: { title: 'Random Event☆' },
+    shop: {
+      title: 'Shop Time☆',
+      close: 'Leave',
+      buy: 'Buy',
+      sell: 'Remove',
+      upgrade: 'Upgrade'
+    },
+    xp: { title: 'XP Gained! +', continue: 'Menu' },
+    gameOver: { retry: 'Retry' },
+    reload: { text: 'Reloading…' },
+    settings: {
+      title: 'Settings',
+      language: 'Language',
+      options: { ja: 'Japanese', en: 'English' },
+      close: 'Close'
+    },
+    credit: { close: 'Close' },
+    progress: { randomEvent: 'Random Event' },
+    events: {
+      spring: {
+        text: 'You found a sparkling spring☆',
+        choices: {
+          drink: 'Drink it💖',
+          skip: 'Leave it'
+        },
+        results: {
+          drink: 'Recovered 20 HP💕',
+          skip: 'Nothing happened~'
+        }
+      },
+      powerStone: {
+        text: 'A suspicious power stone✨ Which ball will you enhance?',
+        choiceLabel: 'Enhance the {type} ball',
+        result: 'The {type} ball powered up✨',
+        passLabel: 'Pass',
+        passResult: 'Didn\u2019t enhance~'
+      },
+      trap: {
+        text: 'Looks like a spiky trap…',
+        choices: {
+          avoid: 'Carefully avoid✨',
+          step: 'Step on it⁉️'
+        },
+        results: {
+          avoid: 'Dodged safely♪',
+          step: 'Ouch... Lost 20 HP💦'
+        }
+      },
+      foundBall: {
+        text: 'A normal ball was lying on the road!',
+        choices: {
+          take: 'Pick it up🎀',
+          skip: 'Maybe not now'
+        },
+        results: {
+          take: 'Got a normal ball☆',
+          skip: 'Skipped it~'
+        }
+      }
+    },
+    history: {
+      title: 'Version History',
+      v1_4: 'v1.4 (2025-08-10) Organized enemy image filenames and updated references',
+      v1_3: 'v1.3 (2025-08-09) Fixed bomb collision bug and added coin icon credit',
+      v1_2: 'v1.2 (2025-08-06) Updated version history',
+      v1_1: 'v1.1 (2025-08-05) Added menu screen & start button, ammo icons and special ball selection, stage progression and enemy HP scale, reload animation, and XP & skill upgrade at stage 5',
+      v1_0: 'v1.0 (2025-08-05) Added XP and skill upgrade for clearing stage 5',
+      v0_9_2: 'v0.9.2 (2025-08-05) Show defeat overlay when player HP reaches 0',
+      v0_9_1: 'v0.9.1 (2025-08-05) Set initial ball count to 3',
+      v0_9: 'v0.9 (2025-08-05) Implemented ammo limit and reload',
+      v0_8: 'v0.8 (2025-08-05) Added bomb pegs',
+      v0_7: 'v0.7 (2025-08-04) Defeat overlay and random images',
+      v0_6: 'v0.6 (2025-08-04) Randomized pegs and yellow peg double damage',
+      v0_5: 'v0.5 (2025-08-04) Victory image and retry button',
+      v0_4: 'v0.4 (2025-08-04) Cumulative damage display and damage confirmation on landing',
+      v0_3: 'v0.3 (2025-08-04) Ball drop damage and effect',
+      v0_2: 'v0.2 (2025-08-04) Temporary image change on enemy damage',
+      v0_1: 'v0.1 (2025-08-03) Initial release'
+    },
+    common: { ok: 'OK' }
   }
 };
+
+let currentLang = 'ja';
+
+export function t(key) {
+  return key.split('.').reduce((o, k) => (o ? o[k] : undefined), translations[currentLang]) || key;
+}
+
+export function setLanguage(lang) {
+  if (!translations[lang]) return;
+  currentLang = lang;
+  document.documentElement.lang = lang;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    const txt = t(key);
+    if (txt !== undefined) {
+      el.textContent = txt;
+    }
+  });
+  localStorage.setItem('lang', lang);
+}

--- a/index.html
+++ b/index.html
@@ -7,31 +7,31 @@
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
 </head>
-  <body>
+<body>
   <div id="container">
     <div id="menu-overlay">
       <div id="main-menu">
-        <h1 id="game-title">Peggy Girls</h1>
-        <button id="start-button" class="menu-option">スタート</button>
-        <button id="upgrade-menu-button" class="menu-option">アップグレード</button>
-        <button id="reset-progress" class="menu-option">進捗リセット</button>
-        <button id="settings-button" class="menu-option">設定</button>
+        <h1 id="game-title" data-i18n="menu.title"></h1>
+        <button id="start-button" class="menu-option" data-i18n="menu.start"></button>
+        <button id="upgrade-menu-button" class="menu-option" data-i18n="menu.upgrade"></button>
+        <button id="reset-progress" class="menu-option" data-i18n="menu.reset"></button>
+        <button id="settings-button" class="menu-option" data-i18n="menu.settings"></button>
       </div>
       <div id="upgrade-buttons">
-        <div id="xp-display">経験値: <span id="xp-value">0</span></div>
-        <button id="upgrade-hp">HPアップ(+10) 10XP</button>
-        <button id="upgrade-atk">攻撃アップ(+10%) 10XP</button>
-        <button id="upgrade-back">戻る</button>
+        <div id="xp-display"><span data-i18n="upgrade.xp"></span><span id="xp-value">0</span></div>
+        <button id="upgrade-hp" data-i18n="upgrade.hp"></button>
+        <button id="upgrade-atk" data-i18n="upgrade.atk"></button>
+        <button id="upgrade-back" data-i18n="upgrade.back"></button>
       </div>
-      <button id="credit-button">クレジット</button>
+      <button id="credit-button" data-i18n="menu.credit"></button>
     </div>
     <div id="player-hp-container">
-      <div id="player-hp-text">HP: <span id="player-hp-value">100</span> / <span id="player-hp-max">100</span></div>
+      <div id="player-hp-text"><span data-i18n="hud.hp"></span><span id="player-hp-value">100</span> / <span id="player-hp-max">100</span></div>
       <div id="player-hp-bar">
         <div id="player-hp-fill"></div>
       </div>
-      <div id="ammo-text">弾: <span id="ammo-value" class="ammo-value"></span></div>
-        <div id="coin-counter"><img id="coin-icon" src="image/items/coin.png" alt="coin"><span id="coin-value">0</span></div>
+      <div id="ammo-text"><span data-i18n="hud.ammo"></span><span id="ammo-value" class="ammo-value"></span></div>
+      <div id="coin-counter"><img id="coin-icon" src="image/items/coin.png" alt="coin"><span id="coin-value">0</span></div>
     </div>
     <div id="game-wrapper">
       <ol id="progress-indicator"></ol>
@@ -39,7 +39,7 @@
       <div id="current-ball"></div>
     </div>
     <div id="side-panel">
-      <div id="stage-text">ステージ: <span id="stage-value">1</span></div>
+      <div id="stage-text"><span data-i18n="hud.stage"></span><span id="stage-value">1</span></div>
       <div class="hp-container">
         <div class="hp-value" id="hp-display">200 / 200</div>
         <div id="hp-bar">
@@ -48,71 +48,68 @@
         </div>
       </div>
       <div id="enemy-image-wrapper">
-        <img id="enemy-girl" src="" alt="敵の女の子">
+        <img id="enemy-girl" src="" alt="enemy">
         <div id="enemy-attack-timer"></div>
       </div>
     </div>
     <div id="victory-overlay">
-        <img id="victory-img" src="image/enemies/enemy_defeat.png" alt="倒された女の子">
+      <img id="victory-img" src="image/enemies/enemy_defeat.png" alt="victory">
     </div>
     <div id="reward-overlay">
-      <h2 id="result-title">リザルト</h2>
-      <div id="reward-coins">
-          <img src="image/items/coin.png" alt="coin">
-        <span id="reward-coin-value">0</span>コインGET
-      </div>
-      <p id="reward-message">報酬ボールを選んでね</p>
+      <h2 id="result-title" data-i18n="reward.title"></h2>
+      <div id="reward-coins"><img src="image/items/coin.png" alt="coin"><span id="reward-coin-value">0</span><span data-i18n="reward.coinSuffix"></span></div>
+      <p id="reward-message" data-i18n="reward.message"></p>
       <div id="reward-buttons">
-          <button class="reward-button" data-type="split">
-            <img src="image/balls/split_ball.png" alt="スプリットボール">
-          <div class="reward-name">スプリットボール</div>
-          <div class="reward-desc">弾が2つに分裂するよ♪</div>
+        <button class="reward-button" data-type="split">
+          <img src="image/balls/split_ball.png" alt="split">
+          <div class="reward-name" data-i18n="balls.split.full"></div>
+          <div class="reward-desc" data-i18n="reward.options.split.desc"></div>
         </button>
-          <button class="reward-button" data-type="heal">
-            <img src="image/balls/recovery_ball.png" alt="ヒールボール">
-          <div class="reward-name">ヒールボール</div>
-          <div class="reward-desc">当たるとHP回復するよ☆</div>
+        <button class="reward-button" data-type="heal">
+          <img src="image/balls/recovery_ball.png" alt="heal">
+          <div class="reward-name" data-i18n="balls.heal.full"></div>
+          <div class="reward-desc" data-i18n="reward.options.heal.desc"></div>
         </button>
-          <button class="reward-button" data-type="big">
-            <img src="image/balls/big_ball.png" alt="ビッグボール">
-          <div class="reward-name">ビッグボール</div>
-          <div class="reward-desc">弾がでかくなるよ☆</div>
+        <button class="reward-button" data-type="big">
+          <img src="image/balls/big_ball.png" alt="big">
+          <div class="reward-name" data-i18n="balls.big.full"></div>
+          <div class="reward-desc" data-i18n="reward.options.big.desc"></div>
         </button>
-          <button class="reward-button" data-type="penetration">
-            <img src="image/balls/penetration_ball.png" alt="ペネトレーションボール">
-          <div class="reward-name">ペネトレーションボール</div>
-          <div class="reward-desc">敵を貫通するよ♡</div>
+        <button class="reward-button" data-type="penetration">
+          <img src="image/balls/penetration_ball.png" alt="penetration">
+          <div class="reward-name" data-i18n="balls.penetration.full"></div>
+          <div class="reward-desc" data-i18n="reward.options.penetration.desc"></div>
         </button>
       </div>
     </div>
     <div id="event-overlay">
-      <h2 id="event-title">ランダムイベント発生☆</h2>
+      <h2 id="event-title" data-i18n="event.title"></h2>
       <p id="event-message"></p>
       <div id="event-options"></div>
     </div>
     <div id="shop-overlay">
-      <h2>ショップだよ☆</h2>
-        <div id="shop-coin-counter"><img src="image/items/coin.png" alt="coin"><span id="shop-coin-value">0</span></div>
+      <h2 data-i18n="shop.title"></h2>
+      <div id="shop-coin-counter"><img src="image/items/coin.png" alt="coin"><span id="shop-coin-value">0</span></div>
       <div id="shop-options"></div>
-      <button id="shop-close">やめる</button>
+      <button id="shop-close" data-i18n="shop.close"></button>
     </div>
     <div id="xp-overlay">
-      <h2>経験値GET! +<span id="xp-gained">0</span></h2>
-      <button id="xp-continue-button">メニューへ</button>
+      <h2><span data-i18n="xp.title"></span><span id="xp-gained">0</span></h2>
+      <button id="xp-continue-button" data-i18n="xp.continue"></button>
     </div>
     <div id="game-over-overlay">
       <h2>gameover😭</h2>
-      <button id="game-over-retry-button">リトライ</button>
+      <button id="game-over-retry-button" data-i18n="gameOver.retry"></button>
     </div>
-    <div id="reload-overlay">リロード中…</div>
-  <div id="settings-overlay">
-      <h2 id="settings-title">設定</h2>
-      <label for="language-select" id="language-label">言語</label>
+    <div id="reload-overlay" data-i18n="reload.text"></div>
+    <div id="settings-overlay">
+      <h2 id="settings-title" data-i18n="settings.title"></h2>
+      <label for="language-select" id="language-label" data-i18n="settings.language"></label>
       <select id="language-select">
-        <option value="ja">日本語</option>
-        <option value="en">English</option>
+        <option value="ja" data-i18n="settings.options.ja"></option>
+        <option value="en" data-i18n="settings.options.en"></option>
       </select>
-      <button id="settings-close">閉じる</button>
+      <button id="settings-close" data-i18n="settings.close"></button>
     </div>
     <div id="credit-overlay">
       <p>Bomb icon by Freepik - Flaticon</p>
@@ -121,29 +118,29 @@
       <p><a href="https://www.flaticon.com/free-icons/bowling" title="bowling icons">Bowling icons created by smashingstocks - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/pet" title="pet icons">Pet icons created by Ylivdesign - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/bamboo" title="bamboo icons">Bamboo icons created by Victoruler - Flaticon</a></p>
-      <button id="credit-close">閉じる</button>
+      <button id="credit-close" data-i18n="credit.close"></button>
     </div>
   </div>
 
   <div id="version-history">
-    <h3>バージョン履歴</h3>
+    <h3 data-i18n="history.title"></h3>
     <ul>
-      <li>v1.4 (2025-08-10) 敵画像ファイル名の整理＆参照更新</li>
-      <li>v1.3 (2025-08-09) 爆弾衝突のバグ修正＆コインアイコンクレジット追加</li>
-      <li>v1.2 (2025-08-06) バージョン履歴を更新</li>
-      <li>v1.1 (2025-08-05) メニュー画面＆スタートボタン、弾数アイコンと特殊弾選択、ステージ進行と敵HPスケール、リロード演出、ステージ5で経験値＆スキル強化を追加</li>
-      <li>v1.0 (2025-08-05) ステージ5クリアで経験値獲得＆スキル強化追加</li>
-      <li>v0.9.2 (2025-08-05) プレイヤーHP0で敗北オーバーレイ表示</li>
-      <li>v0.9.1 (2025-08-05) 初期ボール数を3に設定</li>
-      <li>v0.9 (2025-08-05) 弾数制限とリロードを実装</li>
-      <li>v0.8 (2025-08-05) 爆弾ペグ追加</li>
-      <li>v0.7 (2025-08-04) 敗北オーバーレイとランダム画像</li>
-      <li>v0.6 (2025-08-04) ペグのランダム化と黄色ペグのダブルダメージ</li>
-      <li>v0.5 (2025-08-04) 勝利画像とリトライボタン</li>
-      <li>v0.4 (2025-08-04) 累積ダメージ表示、着地時にダメージ確定</li>
-      <li>v0.3 (2025-08-04) ボール落下ダメージとエフェクト</li>
-      <li>v0.2 (2025-08-04) 敵ダメージ時に画像を一瞬切り替え</li>
-      <li>v0.1 (2025-08-03) 初期リリース</li>
+      <li data-i18n="history.v1_4"></li>
+      <li data-i18n="history.v1_3"></li>
+      <li data-i18n="history.v1_2"></li>
+      <li data-i18n="history.v1_1"></li>
+      <li data-i18n="history.v1_0"></li>
+      <li data-i18n="history.v0_9_2"></li>
+      <li data-i18n="history.v0_9_1"></li>
+      <li data-i18n="history.v0_9"></li>
+      <li data-i18n="history.v0_8"></li>
+      <li data-i18n="history.v0_7"></li>
+      <li data-i18n="history.v0_6"></li>
+      <li data-i18n="history.v0_5"></li>
+      <li data-i18n="history.v0_4"></li>
+      <li data-i18n="history.v0_3"></li>
+      <li data-i18n="history.v0_2"></li>
+      <li data-i18n="history.v0_1"></li>
     </ul>
   </div>
 

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ import { enemyState, startStage } from './enemy.js';
 import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay, updateCoins } from './ui.js';
 import { healBallPath } from './constants.js';
 import { shuffle } from './utils.js';
-import { translations } from './i18n.js';
+import { setLanguage, t } from './i18n.js';
 
 const ballImageMap = {
   normal: './image/balls/normal_ball.png',
@@ -16,119 +16,86 @@ const ballImageMap = {
 
 const randomEvents = [
   {
-    text: 'キラキラの泉を発見したよ☆',
+    textKey: 'events.spring.text',
     choices: [
       {
-        label: 'ゴクゴク飲む💖',
+        labelKey: 'events.spring.choices.drink',
         apply() {
           playerState.playerHP = Math.min(
             playerState.playerMaxHP,
             playerState.playerHP + 20
           );
         },
-        result: 'HPが20回復したよ💕'
+        resultKey: 'events.spring.results.drink'
       },
       {
-        label: 'やめとく〜',
+        labelKey: 'events.spring.choices.skip',
         apply() {},
-        result: '何も変わらなかったよ〜'
+        resultKey: 'events.spring.results.skip'
       }
     ]
   },
   {
-    text: '怪しいパワーストーン✨どのボールを強化する？',
-    // choices can be dynamic based on owned ball types
+    textKey: 'events.powerStone.text',
     choices() {
       const types = [...new Set(playerState.ownedBalls)];
       const opts = types.map(type => ({
         type,
-        label: `${type}ボール強化する〜`,
+        label: t('events.powerStone.choiceLabel').replace('{type}', t(`balls.${type}.full`)),
         apply() {
           playerState.ballLevels[type] = (playerState.ballLevels[type] || 1) + 1;
           updateAmmo();
           updateCurrentBall(firePoint);
         },
-        result: `${type}ボールがパワーアップしたよ✨`
+        result: t('events.powerStone.result').replace('{type}', t(`balls.${type}.full`))
       }));
-      opts.push({ type: null, label: 'やっぱパス', apply() {}, result: '強化しなかったよ〜' });
+      opts.push({ type: null, label: t('events.powerStone.passLabel'), apply() {}, result: t('events.powerStone.passResult') });
       return opts;
     }
   },
   {
-    text: 'トゲトゲの罠があるっぽい…',
+    textKey: 'events.trap.text',
     choices: [
       {
-        label: 'そっと避ける✨',
+        labelKey: 'events.trap.choices.avoid',
         apply() {},
-        result: '上手く避けたよ♪'
+        resultKey: 'events.trap.results.avoid'
       },
       {
-        label: '踏んでみる⁉️',
+        labelKey: 'events.trap.choices.step',
         apply() {
           playerState.playerHP = Math.max(0, playerState.playerHP - 20);
         },
-        result: 'イタタ…HPが20減っちゃった💦'
+        resultKey: 'events.trap.results.step'
       }
     ]
   },
   {
-    text: '道端にノーマルボールが落ちてた！',
+    textKey: 'events.foundBall.text',
     choices: [
       {
-        label: '拾っちゃお🎀',
+        labelKey: 'events.foundBall.choices.take',
         apply() {
-            playerState.ownedBalls.push('normal');
-            playerState.ammo = playerState.ownedBalls.slice();
-            playerState.shotQueue = shuffle(playerState.ammo.slice());
-            enemyState.selectNextBall();
+          playerState.ownedBalls.push('normal');
+          playerState.ammo = playerState.ownedBalls.slice();
+          playerState.shotQueue = shuffle(playerState.ammo.slice());
+          enemyState.selectNextBall();
         },
-        result: 'ノーマルボールゲットだよ☆'
+        resultKey: 'events.foundBall.results.take'
       },
       {
-        label: '今はいらないかも',
+        labelKey: 'events.foundBall.choices.skip',
         apply() {},
-        result: 'スルーしたよ〜'
+        resultKey: 'events.foundBall.results.skip'
       }
     ]
   },
-  {
-    type: 'shop'
-  }
+  { type: 'shop' }
 ];
 
 export let handleShoot;
 
-export function setLanguage(lang) {
-  const t = translations[lang];
-  if (!t) return;
-  document.documentElement.lang = lang;
-  const map = {
-    'start-button': 'startButton',
-    'upgrade-menu-button': 'upgradeMenuButton',
-    'reset-progress': 'resetButton',
-    'settings-button': 'settingsButton',
-    'upgrade-hp': 'upgradeHp',
-    'upgrade-atk': 'upgradeAtk',
-    'upgrade-back': 'upgradeBack',
-    'credit-button': 'creditButton',
-    'settings-title': 'settingsTitle',
-    'settings-close': 'settingsClose',
-    'language-label': 'languageLabel',
-    'xp-continue-button': 'xpContinueButton',
-    'game-over-retry-button': 'gameOverRetryButton'
-  };
-  Object.entries(map).forEach(([id, key]) => {
-    const el = document.getElementById(id);
-    if (el && t[key]) el.textContent = t[key];
-  });
-  const xpDisplay = document.getElementById('xp-display');
-  if (xpDisplay && t.xpDisplay) xpDisplay.childNodes[0].textContent = t.xpDisplay;
-  const ammoText = document.getElementById('ammo-text');
-  if (ammoText && t.ammoText) ammoText.childNodes[0].textContent = t.ammoText;
-  const stageText = document.getElementById('stage-text');
-  if (stageText && t.stageText) stageText.childNodes[0].textContent = t.stageText;
-  localStorage.setItem('language', lang);
-}
+
 
 window.addEventListener('DOMContentLoaded', () => {
   initEngine();
@@ -183,7 +150,7 @@ window.addEventListener('DOMContentLoaded', () => {
       settingsOverlay
     ];
 
-  const savedLang = localStorage.getItem('language') || document.documentElement.lang || 'ja';
+  const savedLang = localStorage.getItem('lang') || document.documentElement.lang || 'ja';
   setLanguage(savedLang);
   if (languageSelect) {
     languageSelect.value = savedLang;
@@ -226,7 +193,7 @@ window.addEventListener('DOMContentLoaded', () => {
       });
       return;
     }
-    eventMessage.textContent = ev.text;
+    eventMessage.textContent = t(ev.textKey);
     eventOptions.innerHTML = '';
     const choices = typeof ev.choices === 'function' ? ev.choices() : ev.choices;
     choices.forEach(choice => {
@@ -234,18 +201,18 @@ window.addEventListener('DOMContentLoaded', () => {
       if (choice.type && ballImageMap[choice.type]) {
         const img = document.createElement('img');
         img.src = ballImageMap[choice.type];
-        img.alt = `${choice.type}ボール`;
+        img.alt = t(`balls.${choice.type}.full`);
         btn.appendChild(img);
       }
       const span = document.createElement('span');
-      span.textContent = choice.label;
+      span.textContent = choice.labelKey ? t(choice.labelKey) : choice.label;
       btn.appendChild(span);
       btn.addEventListener('click', e => {
         e.stopPropagation();
         choice.apply();
         updatePlayerHP();
         updateAmmo();
-        eventMessage.textContent = choice.result;
+        eventMessage.textContent = choice.resultKey ? t(choice.resultKey) : choice.result;
         eventOptions.innerHTML = '';
         let proceeded = false;
         const proceed = () => {
@@ -257,7 +224,7 @@ window.addEventListener('DOMContentLoaded', () => {
         };
         let timer;
         const okBtn = document.createElement('button');
-        okBtn.textContent = 'OK';
+        okBtn.textContent = t('common.ok');
         okBtn.addEventListener('click', e2 => {
           e2.stopPropagation();
           clearTimeout(timer);

--- a/ui.js
+++ b/ui.js
@@ -3,6 +3,7 @@ import { handleShoot } from './main.js';
 import { healBallPath } from './constants.js';
 import { firePoint } from './engine.js';
 import { shuffle } from './utils.js';
+import { t } from './i18n.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -126,11 +127,11 @@ export function updateCoins() {
 }
 
 const shopData = {
-  normal: { label: 'ノーマル', buy: 5, sell: 5, upgrade: 8 },
-  split: { label: 'スプリット', buy: 10, sell: 10, upgrade: 15 },
-  heal: { label: 'ヒール', buy: 10, sell: 10, upgrade: 15 },
-  big: { label: 'ビッグ', buy: 10, sell: 10, upgrade: 15 },
-  penetration: { label: 'ペネトレーション', buy: 10, sell: 10, upgrade: 15 }
+  normal: { buy: 5, sell: 5, upgrade: 8 },
+  split: { buy: 10, sell: 10, upgrade: 15 },
+  heal: { buy: 10, sell: 10, upgrade: 15 },
+  big: { buy: 10, sell: 10, upgrade: 15 },
+  penetration: { buy: 10, sell: 10, upgrade: 15 }
 };
 
 const shopImageMap = {
@@ -150,21 +151,21 @@ export function showShopOverlay(onDone) {
     div.className = 'shop-item';
     const img = document.createElement('img');
     img.src = shopImageMap[type];
-    img.alt = `${data.label}ボール`;
+    img.alt = t(`balls.${type}.full`);
     const label = document.createElement('span');
-    label.textContent = `${data.label}ボール`;
+    label.textContent = t(`balls.${type}.full`);
     const buyBtn = document.createElement('button');
     buyBtn.className = 'shop-buy';
     buyBtn.dataset.type = type;
-    buyBtn.textContent = `購入(${data.buy})`;
+    buyBtn.textContent = `${t('shop.buy')}(${data.buy})`;
     const sellBtn = document.createElement('button');
     sellBtn.className = 'shop-sell';
     sellBtn.dataset.type = type;
-    sellBtn.textContent = `削除(${data.sell})`;
+    sellBtn.textContent = `${t('shop.sell')}(${data.sell})`;
     const upBtn = document.createElement('button');
     upBtn.className = 'shop-upgrade';
     upBtn.dataset.type = type;
-    upBtn.textContent = `強化(${data.upgrade})`;
+    upBtn.textContent = `${t('shop.upgrade')}(${data.upgrade})`;
     div.appendChild(img);
     div.appendChild(label);
     div.appendChild(buyBtn);
@@ -363,7 +364,7 @@ export function updateProgress(enemyState) {
 
     const circle = document.createElement('span');
     circle.classList.add('step-circle');
-    if (step === 'ランダムイベント') {
+    if (step === 'event') {
       circle.textContent = '?';
     } else {
       circle.textContent = enemyCount;


### PR DESCRIPTION
## Summary
- add translations and language switcher
- wire UI text with `data-i18n`
- store language choice in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d787c2c1483309ff2624dc710af72