### PR TITLE
Fix peg generation loop

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -84,7 +84,7 @@ export function generatePegs(count) {
   initialPegCount = count;
   pegs.forEach((p) => World.remove(world, p));
   pegs = [];
-  for (let i = 0; i < count - 1; i++) {
+  for (let i = 0; i < count; i++) {
     const x = 50 + Math.random() * (width - 100);
     const y = 150 + Math.random() * (height - 250);
     const r = Math.random();


### PR DESCRIPTION
## Summary
- ensure generatePegs creates the expected number of pegs by iterating through the full count

## Testing
- `npm test` *(fails: no package.json)*
- `npm install puppeteer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d7e9c61b48330acb786e5dcccab44