### PR TITLE
Clamp player HP at zero

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -25,7 +25,7 @@ export function enemyAttack() {
   if (enemyState.gameOver) {
     return;
   }
-  playerState.playerHP -= 10;
+  playerState.playerHP = Math.max(0, playerState.playerHP - 10);
   updatePlayerHP();
   showDamageOverlay();
   shakeContainer();


### PR DESCRIPTION
## Summary
- prevent player HP from dropping below zero when the enemy attacks

## Testing
- `node --input-type=module -e "global.localStorage={getItem:()=>null}; global.document={getElementById:()=>({style:{}})}; import('./enemy.js').then(m=>{m.playerState.playerHP=5; m.enemyState.gameOver=false; m.enemyAttack(); console.log('HP after attack', m.playerState.playerHP);}).catch(e=>console.error(e))"` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d7f580b1483308b9558b9aa8aedf5