### PR TITLE
feat: show next ball in ammo list

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -83,7 +83,8 @@ export function updatePlayerHP() {
 
 export function updateAmmo() {
   ammoValue.innerHTML = '';
-  playerState.shotQueue.forEach((type, index) => {
+  const queue = [playerState.nextBall, ...playerState.shotQueue].filter(Boolean);
+  queue.forEach((type, index) => {
     const icon = document.createElement('span');
     icon.className = 'ammo-ball';
     if (type === 'normal') {


### PR DESCRIPTION
## Summary
- display `nextBall` at the front of the ammo queue
- keep first ammo icon highlighted as the current shot

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9dd90784833082e5a586705e59a7