### PR TITLE
feat: add elite and boss enemies with rare rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,11 @@
         </button>
       </div>
     </div>
+    <div id="rare-reward-overlay">
+      <h2>レア報酬ゲット！</h2>
+      <p id="rare-reward-desc"></p>
+      <button id="rare-reward-continue">OK</button>
+    </div>
     <div id="event-overlay">
       <h2 id="event-title" data-i18n="event.title"></h2>
       <p id="event-message"></p>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,8 @@
 import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, firePoint, clearSimulatedPath } from './engine.js';
 import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
-import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay, updateCoins, showMapOverlay } from './ui.js';
+import { updateAmmo, updatePlayerHP, updateCurrentBall, updateProgress, showShopOverlay, updateCoins, showMapOverlay, rareRewardOverlay, rareRewardButton } from './ui.js';
+import { applyRareReward } from './rewards.js';
 import { healBallPath } from './constants.js';
 import { shuffle } from './utils.js';
 import { setLanguage, t } from './i18n.js';
@@ -282,7 +283,7 @@ window.addEventListener('DOMContentLoaded', () => {
       });
     } else {
       enemyState.stage += 1;
-      startStage();
+      startStage(node.type);
     }
   }
 
@@ -420,6 +421,24 @@ window.addEventListener('DOMContentLoaded', () => {
       rewardOverlay.style.display = 'none';
       proceedToNextLayer();
     });
+  });
+
+  rareRewardButton.addEventListener('click', (e) => {
+    e.stopPropagation();
+    rareRewardOverlay.style.display = 'none';
+    if (enemyState.pendingRareReward) {
+      applyRareReward(enemyState.pendingRareReward);
+      enemyState.pendingRareReward = null;
+    }
+    if (enemyState.nodeType === 'boss') {
+      const gained = 10;
+      playerState.permXP += gained;
+      localStorage.setItem('permXP', playerState.permXP);
+      xpGained.textContent = gained;
+      xpOverlay.style.display = 'flex';
+    } else {
+      proceedToNextLayer();
+    }
   });
 
   gameOverRetry.addEventListener('click', (e) => {

--- a/rewards.js
+++ b/rewards.js
@@ -1,0 +1,70 @@
+import { playerState } from './player.js';
+import { shuffle } from './utils.js';
+
+export const rareRewardPools = {
+  elite: [
+    {
+      description: '貫通ボールを入手！',
+      apply() {
+        playerState.ownedBalls.push('penetration');
+        if (!playerState.ballLevels.penetration) {
+          playerState.ballLevels.penetration = 1;
+        }
+        playerState.ammo = playerState.ownedBalls.slice();
+        playerState.shotQueue = shuffle(playerState.ammo.slice());
+      }
+    },
+    {
+      description: '20XPを獲得！',
+      apply() {
+        playerState.permXP += 20;
+        localStorage.setItem('permXP', playerState.permXP);
+      }
+    },
+    {
+      description: 'ダブルショットを習得！',
+      apply() {
+        playerState.skills = playerState.skills || [];
+        playerState.skills.push('doubleShot');
+      }
+    }
+  ],
+  boss: [
+    {
+      description: '貫通ボールを入手！',
+      apply() {
+        playerState.ownedBalls.push('penetration');
+        if (!playerState.ballLevels.penetration) {
+          playerState.ballLevels.penetration = 1;
+        }
+        playerState.ammo = playerState.ownedBalls.slice();
+        playerState.shotQueue = shuffle(playerState.ammo.slice());
+      }
+    },
+    {
+      description: '50XPを獲得！',
+      apply() {
+        playerState.permXP += 50;
+        localStorage.setItem('permXP', playerState.permXP);
+      }
+    },
+    {
+      description: 'メガバーストを習得！',
+      apply() {
+        playerState.skills = playerState.skills || [];
+        playerState.skills.push('megaBlast');
+      }
+    }
+  ]
+};
+
+export function getRareReward(type) {
+  const pool = rareRewardPools[type] || [];
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+export function applyRareReward(reward) {
+  if (reward && typeof reward.apply === 'function') {
+    reward.apply();
+  }
+}

--- a/style.css
+++ b/style.css
@@ -747,6 +747,30 @@ canvas {
     border-radius: 8px;
   }
 
+#rare-reward-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+}
+
+#rare-reward-overlay button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  border: 2px solid #ff69b4;
+  background: #fff;
+  color: #ff1493;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
   #credit-overlay {
     position: absolute;
     top: 0;

--- a/ui.js
+++ b/ui.js
@@ -4,6 +4,7 @@ import { healBallPath } from './constants.js';
 import { firePoint } from './engine.js';
 import { shuffle } from './utils.js';
 import { t } from './i18n.js';
+import { getRareReward } from './rewards.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -24,6 +25,9 @@ const progressIndicator = document.getElementById('progress-indicator');
 const shopOverlay = document.getElementById('shop-overlay');
 const shopOptions = document.getElementById('shop-options');
 const shopClose = document.getElementById('shop-close');
+const rareRewardOverlay = document.getElementById('rare-reward-overlay');
+const rareRewardDesc = document.getElementById('rare-reward-desc');
+const rareRewardButton = document.getElementById('rare-reward-continue');
 
 const mapOverlay = document.createElement('div');
 mapOverlay.id = 'map-overlay';
@@ -40,6 +44,13 @@ const nodeIcons = {
 
 export { enemyGirl };
 
+export function showRareRewardOverlay(reward) {
+  rareRewardDesc.textContent = reward.description;
+  rareRewardOverlay.style.display = 'flex';
+}
+
+export { rareRewardOverlay, rareRewardButton };
+
 export function updateAttackCountdown(enemyState) {
   const timer = document.getElementById('enemy-attack-timer');
   if (timer) {
@@ -55,7 +66,12 @@ export function updateHPBar(enemyState) {
   hpDisplay.textContent = `${hp} / ${enemyState.maxEnemyHP}`;
   if (enemyState.enemyHP <= 0 && !enemyState.gameOver) {
     enemyState.gameOver = true;
-    const coinsEarned = enemyState.stage * 3;
+    let coinsEarned = enemyState.stage * 3;
+    if (enemyState.nodeType === 'elite') {
+      coinsEarned = enemyState.stage * 5;
+    } else if (enemyState.nodeType === 'boss') {
+      coinsEarned = enemyState.stage * 10;
+    }
     playerState.coins += coinsEarned;
     updateCoins();
     document.getElementById('reward-coin-value').textContent = coinsEarned;
@@ -68,12 +84,10 @@ export function updateHPBar(enemyState) {
         victoryOverlay.style.display = 'none';
         enemyState.gameOver = false;
         document.getElementById('aim-svg').addEventListener('click', handleShoot);
-        if (enemyState.stage >= 5) {
-          const gained = 10;
-          playerState.permXP += gained;
-          localStorage.setItem('permXP', playerState.permXP);
-          xpGained.textContent = gained;
-          xpOverlay.style.display = 'flex';
+        if (enemyState.nodeType === 'elite' || enemyState.nodeType === 'boss') {
+          const reward = getRareReward(enemyState.nodeType);
+          enemyState.pendingRareReward = reward;
+          showRareRewardOverlay(reward);
         } else {
           rewardOverlay.style.display = 'flex';
         }


### PR DESCRIPTION
## Summary
- add elite & boss enemy variants with stronger stats and images
- show rare reward overlay after elite/boss defeat
- define rare reward pools and integrate with stage flow

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check enemy.js main.js ui.js rewards.js`


------
https://chatgpt.com/codex/tasks/task_e_689da45681e48330931e51edbec94410