### PR TITLE
Use Matter.js 0.19.0 via CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
     </ul>
   </div>
 
-  <script src="lib/matter.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
   <script>
     if (!window.Matter) {
       document.body.insertAdjacentHTML('beforeend', '<p>Matter.js の読み込みに失敗しました。</p>');

--- a/lib/matter.min.js
+++ b/lib/matter.min.js
@@ -1,1 +1,0 @@
-// TODO: matter.min.js v0.19.0 should be placed here. Download failed due to network restrictions.


### PR DESCRIPTION
## Summary
- Load Matter.js v0.19.0 from jsDelivr CDN
- Remove outdated local `matter.min.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db3fb1fa88330856db5c574776307