### PR TITLE
Add mini-map overlay to UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <div id="container">
+    <div id="mini-map"></div>
     <div id="menu-overlay">
       <div id="main-menu">
         <h1 id="game-title" data-i18n="menu.title"></h1>

--- a/style.css
+++ b/style.css
@@ -51,6 +51,39 @@ html, body {
   z-index: 10;
   pointer-events: none;
 }
+
+#mini-map {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 200px;
+  height: 200px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 2px solid #ff69b4;
+  border-radius: 8px;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+#mini-map .map-node {
+  width: 10px;
+  height: 10px;
+  margin: 0;
+  font-size: 10px;
+  cursor: default;
+}
+
+#mini-map .map-node.current {
+  outline: 1px solid yellow;
+}
+
+#mini-map .map-connection {
+  stroke-width: 1px;
+}
+
+#mini-map .map-connection.active {
+  stroke-width: 2px;
+}
 #player-hp-text {
   font-size: 14px;
   font-weight: bold;

--- a/ui.js
+++ b/ui.js
@@ -327,6 +327,74 @@ export function showMapOverlay(mapState, onSelect) {
   mapOverlay.style.display = 'flex';
 }
 
+export function renderMiniMap(mapState) {
+  const miniMap = document.getElementById('mini-map');
+  if (!miniMap) return;
+  miniMap.innerHTML = '';
+  const area = document.createElement('div');
+  area.style.position = 'relative';
+  area.style.width = '100%';
+  area.style.height = '100%';
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '200');
+  svg.setAttribute('height', '200');
+  svg.style.position = 'absolute';
+  svg.style.left = '0';
+  svg.style.top = '0';
+  svg.style.pointerEvents = 'none';
+  area.appendChild(svg);
+  miniMap.appendChild(area);
+  const scaleX = 200 / 600;
+  const scaleY = 200 / 500;
+
+  const isActiveConnection = (a, b) => {
+    for (let i = 0; i < mapState.path.length - 1; i++) {
+      if (mapState.path[i] === a && mapState.path[i + 1] === b) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  mapState.layers.forEach((layer) => {
+    layer.forEach((node) => {
+      const el = document.createElement('div');
+      el.className = 'map-node';
+      el.textContent = nodeIcons[node.type] || '';
+      el.style.position = 'absolute';
+      el.style.left = `${node.x * scaleX}px`;
+      el.style.top = `${node.y * scaleY}px`;
+      el.style.pointerEvents = 'none';
+      if (node.completed) {
+        el.classList.add('done');
+      }
+      if (mapState.currentNode === node) {
+        el.classList.add('current');
+      }
+      area.appendChild(el);
+    });
+  });
+
+  mapState.layers.forEach((layer, li) => {
+    if (li >= mapState.layers.length - 1) return;
+    layer.forEach((node) => {
+      node.connections.forEach((nextIndex) => {
+        const nextNode = mapState.layers[li + 1][nextIndex];
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', node.x * scaleX + 5);
+        line.setAttribute('y1', node.y * scaleY + 5);
+        line.setAttribute('x2', nextNode.x * scaleX + 5);
+        line.setAttribute('y2', nextNode.y * scaleY + 5);
+        line.classList.add('map-connection');
+        if (isActiveConnection(node, nextNode)) {
+          line.classList.add('active');
+        }
+        svg.appendChild(line);
+      });
+    });
+  });
+}
+
 export function updateCurrentBall(firePoint) {
   if (!playerState.nextBall) {
     currentBallEl.style.display = 'none';
@@ -480,6 +548,7 @@ export function updateProgress(state) {
       progressIndicator.appendChild(li);
     });
   }
+  renderMiniMap(state);
 }
 
 updateCoins();


### PR DESCRIPTION
## Summary
- Add `#mini-map` container and styles for a fixed top-right mini map.
- Render a small state map via new `renderMiniMap` function and update it with progress.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dba8b4b388330bcd14386c748ccc0