### PR TITLE
feat: show map overlay after boss and progression

### DIFF
--- a/main.js
+++ b/main.js
@@ -269,10 +269,8 @@ window.addEventListener('DOMContentLoaded', () => {
       updateProgress(mapState);
     }
     mapState.currentLayer += 1;
-    if (mapState.currentLayer < mapState.layers.length) {
-      mapState.currentNode = current;
-      showMapOverlay(mapState, handleNodeSelection);
-    }
+    mapState.currentNode = current;
+    showMapOverlay(mapState, handleNodeSelection);
   }
 
   function handleNodeSelection(index) {
@@ -451,9 +449,8 @@ window.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('permXP', playerState.permXP);
       xpGained.textContent = gained;
       xpOverlay.style.display = 'flex';
-    } else {
-      proceedToNextLayer();
     }
+    proceedToNextLayer();
   });
 
   gameOverRetry.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- always display map overlay when advancing layers
- trigger next layer after claiming rare rewards, even for bosses

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689dbbb8ffcc83309041cdfbbc37c24e