### PR TITLE
Limit map connections to nearest nodes

### DIFF
--- a/main.js
+++ b/main.js
@@ -128,8 +128,21 @@ export function generateMap({ layerCount = 5, nodesPerLayer = 3, bossAtEnd = fal
     mapState.layers.push(layer);
   }
   for (let i = 0; i < mapState.layers.length - 1; i++) {
+    const nextLayer = mapState.layers[i + 1];
     mapState.layers[i].forEach((node) => {
-      node.connections = mapState.layers[i + 1].map((_, idx) => idx);
+      const sorted = nextLayer
+        .map((nextNode, idx) => ({ idx, diff: Math.abs(node.x - nextNode.x) }))
+        .sort((a, b) => a.diff - b.diff)
+        .map((obj) => obj.idx);
+
+      const maxConnections = Math.min(nextLayer.length, 3);
+      const minConnections = Math.min(nextLayer.length, 2);
+      const connectionCount =
+        maxConnections === minConnections
+          ? maxConnections
+          : minConnections + Math.floor(Math.random() * (maxConnections - minConnections + 1));
+
+      node.connections = sorted.slice(0, connectionCount);
     });
   }
   mapState.currentLayer = 0;


### PR DESCRIPTION
## Summary
- Generate map connections only to 2-3 closest nodes in next layer

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689dbd6a3f1c833091f4b9d3602da516