### PR TITLE
fix: ボス撃破後ステージ2に進めない不具合を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -465,8 +465,9 @@ window.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('permXP', playerState.permXP);
       xpGained.textContent = gained;
       xpOverlay.style.display = 'flex';
+    } else {
+      proceedToNextLayer();
     }
-    proceedToNextLayer();
   });
 
   gameOverRetry.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- ボス戦後にマップが先に表示されXP画面が隠れる問題を修正し、次ステージへ進めるようにした

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689dcbb38f488330bbd362eb298e7b43