### PR TITLE
Add version entry for fourth character

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -100,6 +100,7 @@ export const translations = {
     },
     history: {
       title: 'バージョン履歴',
+      v1_5: 'v1.5 (2025-08-11) 4人目キャラ追加',
       v1_4: 'v1.4 (2025-08-10) 敵画像ファイル名の整理＆参照更新',
       v1_3: 'v1.3 (2025-08-09) 爆弾衝突のバグ修正＆コインアイコンクレジット追加',
       v1_2: 'v1.2 (2025-08-06) バージョン履歴を更新',
@@ -220,6 +221,7 @@ export const translations = {
     },
     history: {
       title: 'Version History',
+      v1_5: 'v1.5 (2025-08-11) Added 4th character',
       v1_4: 'v1.4 (2025-08-10) Organized enemy image filenames and updated references',
       v1_3: 'v1.3 (2025-08-09) Fixed bomb collision bug and added coin icon credit',
       v1_2: 'v1.2 (2025-08-06) Updated version history',

--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
   <div id="version-history">
     <h3 data-i18n="history.title"></h3>
     <ul>
+      <li data-i18n="history.v1_5"></li>
       <li data-i18n="history.v1_4"></li>
       <li data-i18n="history.v1_3"></li>
       <li data-i18n="history.v1_2"></li>


### PR DESCRIPTION
## Summary
- add v1.5 entry about fourth character to Japanese and English translations
- display new v1.5 entry in version history list

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689ed16bb7d48330b9557d6d1490f3b7