### PR TITLE
Add map overlay touch support and pointer events

### DIFF
--- a/style.css
+++ b/style.css
@@ -820,6 +820,7 @@ canvas {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  pointer-events: auto;
 }
 
 .map-node {
@@ -833,6 +834,8 @@ canvas {
   justify-content: center;
   cursor: pointer;
   font-size: 24px;
+  pointer-events: auto;
+  z-index: 1001;
 }
 
 .map-node.done {

--- a/ui.js
+++ b/ui.js
@@ -279,6 +279,9 @@ export function showMapOverlay(mapState, onSelect) {
         el.classList.add('disabled');
       }
       area.appendChild(el);
+      el.addEventListener('click', () => {
+        console.log('map node clicked', li, ni);
+      });
     });
   });
 
@@ -311,6 +314,7 @@ export function showMapOverlay(mapState, onSelect) {
   });
   if (mapOverlayHandler) {
     mapOverlay.removeEventListener('click', mapOverlayHandler);
+    mapOverlay.removeEventListener('touchstart', mapOverlayHandler);
   }
   mapOverlayHandler = (e) => {
     const target = e.target.closest('.map-node');
@@ -323,6 +327,7 @@ export function showMapOverlay(mapState, onSelect) {
     onSelect && onSelect(idx);
   };
   mapOverlay.addEventListener('click', mapOverlayHandler);
+  mapOverlay.addEventListener('touchstart', mapOverlayHandler);
   mapOverlay.style.display = 'flex';
 }
 


### PR DESCRIPTION
## Summary
- log map node clicks for debugging
- enable touchstart handling on the map overlay
- ensure map overlay and nodes capture pointer events with proper z-index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed1ffec348330b3793b1ef997952d