### PR TITLE
Use show class for overlays

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -50,7 +50,7 @@ export function enemyAttack() {
   shakeContainer();
   if (playerState.playerHP <= 0 && !enemyState.gameOver) {
     enemyState.gameOver = true;
-    document.getElementById('game-over-overlay').style.display = 'flex';
+    document.getElementById('game-over-overlay').classList.add('show');
   } else {
     enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
     updateAttackCountdown(enemyState);

--- a/main.js
+++ b/main.js
@@ -214,18 +214,14 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   const isAnyOverlayVisible = () =>
-    overlays.some(o => window.getComputedStyle(o).display !== 'none');
+    overlays.some(o => o.classList.contains('show'));
 
   const showOverlay = (overlay) => {
-    overlay.style.display = 'flex';
-    requestAnimationFrame(() => overlay.classList.add('show'));
+    overlay.classList.add('show');
   };
 
   const hideOverlay = (overlay) => {
     overlay.classList.remove('show');
-    overlay.addEventListener('transitionend', () => {
-      overlay.style.display = 'none';
-    }, { once: true });
   };
 
   showOverlay(menuOverlay);
@@ -265,14 +261,14 @@ window.addEventListener('DOMContentLoaded', () => {
         okBtn.textContent = t('common.ok');
         okBtn.addEventListener('click', e2 => {
           e2.stopPropagation();
-          eventOverlay.style.display = 'none';
+          hideOverlay(eventOverlay);
           onDone && onDone();
         });
         eventOptions.appendChild(okBtn);
       });
       eventOptions.appendChild(btn);
     });
-    eventOverlay.style.display = 'flex';
+    showOverlay(eventOverlay);
   }
 
   function proceedToNextLayer() {
@@ -307,12 +303,12 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   const startReload = () => {
-    reloadOverlay.style.display = 'flex';
+    showOverlay(reloadOverlay);
     playerState.reloading = true;
     setTimeout(() => {
       playerState.ammo = playerState.ownedBalls.slice();
       playerState.shotQueue = shuffle(playerState.ammo.slice());
-      reloadOverlay.style.display = 'none';
+      hideOverlay(reloadOverlay);
       enemyState.selectNextBall();
       playerState.reloading = false;
     }, 1000);
@@ -384,7 +380,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     xpContinue.addEventListener('click', (e) => {
       e.stopPropagation();
-      xpOverlay.style.display = 'none';
+      hideOverlay(xpOverlay);
       worldStage += 1;
       enemyState.stage = 0;
       mapState.currentLayer = 0;
@@ -447,7 +443,7 @@ window.addEventListener('DOMContentLoaded', () => {
       playerState.ammo = playerState.ownedBalls.slice();
       playerState.shotQueue = shuffle(playerState.ammo.slice());
       enemyState.selectNextBall();
-      rewardOverlay.style.display = 'none';
+      hideOverlay(rewardOverlay);
       proceedToNextLayer();
     });
   });
@@ -464,7 +460,7 @@ window.addEventListener('DOMContentLoaded', () => {
       playerState.permXP += gained;
       localStorage.setItem('permXP', playerState.permXP);
       xpGained.textContent = gained;
-      xpOverlay.style.display = 'flex';
+      showOverlay(xpOverlay);
     } else {
       proceedToNextLayer();
     }
@@ -472,7 +468,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   gameOverRetry.addEventListener('click', (e) => {
     e.stopPropagation();
-    gameOverOverlay.style.display = 'none';
+    hideOverlay(gameOverOverlay);
     worldStage = 0;
     enemyState.stage = 0;
     enemyState.gameOver = false;

--- a/style.css
+++ b/style.css
@@ -611,7 +611,7 @@ canvas {
   width: 100%;
   height: 100%;
   background: rgba(255, 255, 255, 0.9);
-  display: flex;
+  display: none;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -622,6 +622,7 @@ canvas {
 }
 
 #menu-overlay.show {
+  display: flex;
   opacity: 1;
   transform: scale(1);
 }
@@ -699,6 +700,16 @@ canvas {
   align-items: center;
   justify-content: center;
   z-index: 30;
+}
+
+#xp-overlay.show,
+#reward-overlay.show,
+#event-overlay.show,
+#game-over-overlay.show,
+#reload-overlay.show,
+#victory-overlay.show,
+#shop-overlay.show {
+  display: flex;
 }
 
   #xp-overlay button {

--- a/ui.js
+++ b/ui.js
@@ -79,10 +79,10 @@ export function updateHPBar(enemyState) {
     localStorage.setItem('coins', playerState.coins);
     setTimeout(() => {
       victoryImg.src = enemyState.defeatImages[Math.floor(Math.random() * enemyState.defeatImages.length)];
-      victoryOverlay.style.display = 'flex';
+      victoryOverlay.classList.add('show');
       document.getElementById('aim-svg').removeEventListener('click', handleShoot);
       const proceed = () => {
-        victoryOverlay.style.display = 'none';
+        victoryOverlay.classList.remove('show');
         enemyState.gameOver = false;
         document.getElementById('aim-svg').addEventListener('click', handleShoot);
         if (enemyState.nodeType === 'elite' || enemyState.nodeType === 'boss') {
@@ -90,7 +90,7 @@ export function updateHPBar(enemyState) {
           enemyState.pendingRareReward = reward;
           showRareRewardOverlay(reward);
         } else {
-          rewardOverlay.style.display = 'flex';
+          rewardOverlay.classList.add('show');
         }
       };
       victoryOverlay.addEventListener('click', (e) => { e.stopPropagation(); proceed(); }, { once: true });
@@ -171,7 +171,7 @@ const shopImageMap = {
 };
 
 export function showShopOverlay(onDone) {
-  shopOverlay.style.display = 'flex';
+  shopOverlay.classList.add('show');
   updateCoins();
   shopOptions.innerHTML = '';
   Object.entries(shopData).forEach(([type, data]) => {
@@ -228,7 +228,7 @@ export function showShopOverlay(onDone) {
     playerState.shotQueue = shuffle(playerState.ammo.slice());
     localStorage.setItem('coins', playerState.coins);
     shopOptions.removeEventListener('click', handleClick);
-    shopOverlay.style.display = 'none';
+    shopOverlay.classList.remove('show');
     selectNextBall(firePoint);
     updateCoins();
     onDone && onDone();
@@ -238,7 +238,7 @@ export function showShopOverlay(onDone) {
 
   shopClose.onclick = () => {
     shopOptions.removeEventListener('click', handleClick);
-    shopOverlay.style.display = 'none';
+    shopOverlay.classList.remove('show');
     onDone && onDone();
   };
 }


### PR DESCRIPTION
## Summary
- hide the menu overlay by default and show via `show` class
- toggle `show` class in JS for overlay visibility detection
- update shop and victory overlays to follow the same show class approach

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689ed36cce088330a21a20b3822e4402