### PR TITLE
Remove mini-map overlay styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,9 +58,6 @@ html, body {
   right: 16px;
   width: 200px;
   height: 200px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 2px solid #ff69b4;
-  border-radius: 8px;
   pointer-events: none;
   z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- strip background and borders from the mini-map overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed548f94c8330ac97fbd464f4a80a