### PR TITLE
Scope map overlay to game wrapper

### DIFF
--- a/style.css
+++ b/style.css
@@ -818,7 +818,7 @@ canvas {
 }
 
 #map-overlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;

--- a/ui.js
+++ b/ui.js
@@ -32,7 +32,7 @@ const rareRewardButton = document.getElementById('rare-reward-continue');
 const mapOverlay = document.createElement('div');
 mapOverlay.id = 'map-overlay';
 mapOverlay.style.display = 'none';
-document.getElementById('container').appendChild(mapOverlay);
+document.getElementById('game-wrapper').appendChild(mapOverlay);
 let mapOverlayHandler;
 
 const nodeIcons = {


### PR DESCRIPTION
## Summary
- Append map overlay to `#game-wrapper` instead of overall container
- Position `#map-overlay` absolutely so it covers only the game area

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed70aec8483309a42a6017e9a2b66