### PR TITLE
fix: clamp map layer index to boss layer

### DIFF
--- a/main.js
+++ b/main.js
@@ -277,9 +277,18 @@ window.addEventListener('DOMContentLoaded', () => {
       current.completed = true;
       updateMapDisplay(mapState);
     }
-    mapState.currentLayer += 1;
+    const maxLayerIndex = mapState.layers.length - 1;
+    mapState.currentLayer = Math.min(
+      mapState.currentLayer + 1,
+      maxLayerIndex
+    );
     mapState.currentNode = current;
-    showMapOverlay(mapState, handleNodeSelection);
+    if (
+      mapState.currentLayer >= 0 &&
+      mapState.currentLayer < mapState.layers.length
+    ) {
+      showMapOverlay(mapState, handleNodeSelection);
+    }
   }
 
   function handleNodeSelection(index) {


### PR DESCRIPTION
## Summary
- clamp `mapState.currentLayer` to last layer before updating
- ensure map overlay only shown when current layer is valid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed8c734a483308814851ccc0e1966