### PR TITLE
feat: add relic rewards after boss

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -323,6 +323,9 @@ function handlePenetrationHits() {
         let damage = 10;
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + playerState.atkLevel * 0.1;
+        if (playerState.relics && playerState.relics.includes('damageBoost')) {
+          damage += Math.floor(Math.random() * 3) + 1;
+        }
         enemyState.pendingDamage += damage;
         showDamageText(Math.round(peg.position.x), Math.round(peg.position.y), '+' + Math.round(enemyState.pendingDamage), ball.ballType === 'heal');
         if (ball.ballType === 'heal') {
@@ -346,6 +349,9 @@ function handlePenetrationHits() {
         let damage = peg.label === 'peg-yellow' ? 20 : 10;
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + playerState.atkLevel * 0.1;
+        if (playerState.relics && playerState.relics.includes('damageBoost')) {
+          damage += Math.floor(Math.random() * 3) + 1;
+        }
         enemyState.pendingDamage += damage;
         showDamageText(Math.round(peg.position.x), Math.round(peg.position.y), '+' + Math.round(enemyState.pendingDamage), ball.ballType === 'heal');
         if (ball.ballType === 'heal') {
@@ -380,6 +386,9 @@ export function setupCollisionHandler() {
         let damage = 10;
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + playerState.atkLevel * 0.1;
+        if (playerState.relics && playerState.relics.includes('damageBoost')) {
+          damage += Math.floor(Math.random() * 3) + 1;
+        }
         enemyState.pendingDamage += damage;
         showDamageText(Math.round(peg.position.x), Math.round(peg.position.y), '+' + Math.round(enemyState.pendingDamage), ball.ballType === 'heal');
         if (ball.ballType === 'heal') {
@@ -406,6 +415,9 @@ export function setupCollisionHandler() {
         let damage = peg.label === 'peg-yellow' ? 20 : 10;
         damage *= ball.damageMultiplier || 1;
         damage *= 1 + playerState.atkLevel * 0.1;
+        if (playerState.relics && playerState.relics.includes('damageBoost')) {
+          damage += Math.floor(Math.random() * 3) + 1;
+        }
         enemyState.pendingDamage += damage;
         showDamageText(Math.round(peg.position.x), Math.round(peg.position.y), '+' + Math.round(enemyState.pendingDamage), ball.ballType === 'heal');
         if (ball.ballType === 'heal') {
@@ -416,6 +428,11 @@ export function setupCollisionHandler() {
       }
       if (labels.includes('ball') && labels.includes('bottom-sensor')) {
         const ball = pair.bodyA.label === 'ball' ? pair.bodyA : pair.bodyB;
+        if (playerState.relics && playerState.relics.includes('rebound') && Math.random() < 0.5) {
+          Body.setPosition(ball, { x: ball.position.x, y: 0 });
+          Body.setVelocity(ball, { x: 0, y: 20 });
+          return;
+        }
         const { x, y } = ball.position;
         World.remove(world, ball);
         playerState.currentBalls = playerState.currentBalls.filter(b => b !== ball);
@@ -446,6 +463,9 @@ export function setupCollisionHandler() {
           playerState.currentShotType = null;
           currentShotHits = 0;
           enemyState.attackCountdown--;
+          if (playerState.relics && playerState.relics.includes('timeLag') && Math.random() < 0.2) {
+            enemyState.attackCountdown++;
+          }
           if (enemyState.attackCountdown <= 0 && enemyState.enemyHP > 0) {
             enemyState.enemyAttack();
             launchHeartAttack();
@@ -475,6 +495,9 @@ export function explodeBomb(peg, ball) {
         let dmg = body.label === 'peg-yellow' ? 20 : 10;
         dmg *= ball.damageMultiplier || 1;
         dmg *= 1 + playerState.atkLevel * 0.1;
+        if (playerState.relics && playerState.relics.includes('damageBoost')) {
+          dmg += Math.floor(Math.random() * 3) + 1;
+        }
         enemyState.pendingDamage += dmg;
         showDamageText(Math.round(body.position.x), Math.round(body.position.y), '+' + Math.round(enemyState.pendingDamage), ball.ballType === 'heal');
         if (ball.ballType === 'heal') {

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
     </div>
     <div id="rare-reward-overlay">
       <h2>レア報酬ゲット！</h2>
+      <div id="rare-reward-icon"></div>
       <p id="rare-reward-desc"></p>
       <button id="rare-reward-continue">OK</button>
     </div>

--- a/player.js
+++ b/player.js
@@ -12,5 +12,6 @@ export const playerState = {
   permXP: parseInt(localStorage.getItem('permXP') || '0', 10),
   hpLevel: parseInt(localStorage.getItem('hpLevel') || '0', 10),
   atkLevel: parseInt(localStorage.getItem('atkLevel') || '0', 10),
-  coins: parseInt(localStorage.getItem('coins') || '0', 10)
+  coins: parseInt(localStorage.getItem('coins') || '0', 10),
+  relics: []
 };

--- a/relics.js
+++ b/relics.js
@@ -1,0 +1,45 @@
+import { playerState } from './player.js';
+
+export const relicList = [
+  {
+    key: 'timeLag',
+    name: 'タイムラグ',
+    description: '1/5の確率で敵の攻撃を1ターン遅くする',
+    icon: '⏳'
+  },
+  {
+    key: 'rebound',
+    name: 'リバウンド',
+    description: '1/2の確率で落下したボールが再落下する',
+    icon: '🔄'
+  },
+  {
+    key: 'killHeal',
+    name: 'キルヒール',
+    description: '敵撃破でHP10回復',
+    icon: '💖'
+  },
+  {
+    key: 'damageBoost',
+    name: 'ダメブースト',
+    description: 'ペグ破壊時に追加ダメージ1~3',
+    icon: '💥'
+  },
+  {
+    key: 'coinCharm',
+    name: 'コインチャーム',
+    description: '敵撃破でコイン10追加',
+    icon: '💰'
+  }
+];
+
+export function addRelic(key) {
+  playerState.relics = playerState.relics || [];
+  if (!playerState.relics.includes(key)) {
+    playerState.relics.push(key);
+  }
+}
+
+export function getRandomRelic() {
+  return relicList[Math.floor(Math.random() * relicList.length)];
+}

--- a/rewards.js
+++ b/rewards.js
@@ -1,5 +1,6 @@
 import { playerState } from './player.js';
 import { shuffle } from './utils.js';
+import { addRelic, getRandomRelic } from './relics.js';
 
 export const rareRewardPools = {
   elite: [
@@ -48,19 +49,24 @@ export const rareRewardPools = {
         localStorage.setItem('permXP', playerState.permXP);
       }
     },
-    {
-      description: 'メガバーストを習得！',
-      apply() {
-        playerState.skills = playerState.skills || [];
-        playerState.skills.push('megaBlast');
-      }
-    }
+    { type: 'relic' }
   ]
 };
 
 export function getRareReward(type) {
   const pool = rareRewardPools[type] || [];
-  return pool[Math.floor(Math.random() * pool.length)];
+  const reward = pool[Math.floor(Math.random() * pool.length)];
+  if (reward.type === 'relic') {
+    const relic = getRandomRelic();
+    return {
+      description: `${relic.name}を入手！`,
+      icon: relic.icon,
+      apply() {
+        addRelic(relic.key);
+      }
+    };
+  }
+  return reward;
 }
 
 export function applyRareReward(reward) {

--- a/style.css
+++ b/style.css
@@ -733,6 +733,16 @@ canvas {
   z-index: 30;
 }
 
+#rare-reward-icon {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 10px;
+  font-size: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 #rare-reward-overlay button {
   margin-top: 20px;
   padding: 10px 20px;

--- a/ui.js
+++ b/ui.js
@@ -27,6 +27,7 @@ const shopOptions = document.getElementById('shop-options');
 const shopClose = document.getElementById('shop-close');
 const rareRewardOverlay = document.getElementById('rare-reward-overlay');
 const rareRewardDesc = document.getElementById('rare-reward-desc');
+const rareRewardIcon = document.getElementById('rare-reward-icon');
 const rareRewardButton = document.getElementById('rare-reward-continue');
 
 const mapOverlay = document.createElement('div');
@@ -47,6 +48,12 @@ export { enemyGirl };
 
 export function showRareRewardOverlay(reward) {
   rareRewardDesc.textContent = reward.description;
+  if (reward.icon) {
+    rareRewardIcon.textContent = reward.icon;
+    rareRewardIcon.style.display = 'block';
+  } else {
+    rareRewardIcon.style.display = 'none';
+  }
   rareRewardOverlay.style.display = 'flex';
 }
 
@@ -73,10 +80,17 @@ export function updateHPBar(enemyState) {
     } else if (enemyState.nodeType === 'boss') {
       coinsEarned = enemyState.stage * 10;
     }
+    if (playerState.relics && playerState.relics.includes('coinCharm')) {
+      coinsEarned += 10;
+    }
     playerState.coins += coinsEarned;
     updateCoins();
     document.getElementById('reward-coin-value').textContent = coinsEarned;
     localStorage.setItem('coins', playerState.coins);
+    if (playerState.relics && playerState.relics.includes('killHeal')) {
+      playerState.playerHP = Math.min(playerState.playerMaxHP, playerState.playerHP + 10);
+      updatePlayerHP();
+    }
     setTimeout(() => {
       victoryImg.src = enemyState.defeatImages[Math.floor(Math.random() * enemyState.defeatImages.length)];
       victoryOverlay.classList.add('show');


### PR DESCRIPTION
## Summary
- add relic system and random relic reward after boss fights
- show relic icon and apply unique effects like time lag, rebound, healing, damage boost, and coin charm
- replace relic icon images with emoji to avoid binary files

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed98944dc8330ae8396b19add5563