### PR TITLE
Add Flaticon icon credits

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,8 @@
     </div>
     <div id="credit-overlay">
       <p>Bomb icon by Freepik - Flaticon</p>
+      <p><a href="https://www.flaticon.com/free-icons/coin" title="coin icons">Coin icons created by popo2021 - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/heart" title="heart icons">Heart icons created by Fathema Khanom - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/resurgence" title="resurgence icons">Resurgence icons created by Uniconlabs - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/boost" title="boost icons">Boost icons created by Freepik - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/coin" title="coin icons">Coin icons created by kliwir art - Flaticon</a></p>

--- a/index.html
+++ b/index.html
@@ -118,8 +118,11 @@
     </div>
     <div id="credit-overlay">
       <p>Bomb icon by Freepik - Flaticon</p>
-      <p><a href="https://www.flaticon.com/free-icons/coin" title="coin icons">Coin icons created by popo2021 - Flaticon</a></p>
-      <p><a href="https://www.flaticon.com/free-icons/heart" title="heart icons">Heart icons created by Fathema Khanom - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/resurgence" title="resurgence icons">Resurgence icons created by Uniconlabs - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/boost" title="boost icons">Boost icons created by Freepik - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/coin" title="coin icons">Coin icons created by kliwir art - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/heart" title="heart icons">Heart icons created by Freepik - Flaticon</a></p>
+      <p><a href="https://www.flaticon.com/free-icons/time" title="time icons">Time icons created by Freepik - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/bowling" title="bowling icons">Bowling icons created by smashingstocks - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/pet" title="pet icons">Pet icons created by Ylivdesign - Flaticon</a></p>
       <p><a href="https://www.flaticon.com/free-icons/bamboo" title="bamboo icons">Bamboo icons created by Victoruler - Flaticon</a></p>


### PR DESCRIPTION
## Summary
- add credits for new Flaticon icons in credit overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edfad79608330b7a7970b0738cbe7