### PR TITLE
feat: replace relic emoji with image icons

### DIFF
--- a/image/relics/coin_charm.svg
+++ b/image/relics/coin_charm.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="20" fill="#ffd700" stroke="#b8860b" stroke-width="4"/>
+  <circle cx="32" cy="32" r="8" fill="#fff" opacity="0.5"/>
+</svg>

--- a/image/relics/damage_boost.svg
+++ b/image/relics/damage_boost.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <polygon points="32,4 38,24 60,24 42,38 48,58 32,46 16,58 22,38 4,24 26,24" fill="#ff69b4"/>
+</svg>

--- a/image/relics/kill_heal.svg
+++ b/image/relics/kill_heal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M32 58 L8 34 A14 14 0 1 1 32 18 A14 14 0 1 1 56 34 Z" fill="#ff69b4"/>
+</svg>

--- a/image/relics/rebound.svg
+++ b/image/relics/rebound.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="44" r="10" fill="#ff69b4"/>
+  <path d="M12 20 Q32 0 52 20" stroke="#555" stroke-width="4" fill="none"/>
+  <polyline points="44,12 52,20 44,28" stroke="#555" stroke-width="4" fill="none"/>
+</svg>

--- a/image/relics/time_lag.svg
+++ b/image/relics/time_lag.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="20" y="0" width="24" height="6" fill="#555"/>
+  <rect x="20" y="58" width="24" height="6" fill="#555"/>
+  <polygon points="20,6 44,6 32,30" fill="#ff69b4"/>
+  <polygon points="20,58 44,58 32,34" fill="#ff69b4"/>
+  <rect x="31" y="30" width="2" height="4" fill="#555"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
     </div>
     <div id="rare-reward-overlay">
       <h2>レア報酬ゲット！</h2>
-      <div id="rare-reward-icon"></div>
+      <img id="rare-reward-icon" alt="rare icon" />
       <p id="rare-reward-desc"></p>
       <button id="rare-reward-continue">OK</button>
     </div>

--- a/relics.js
+++ b/relics.js
@@ -5,31 +5,31 @@ export const relicList = [
     key: 'timeLag',
     name: 'タイムラグ',
     description: '1/5の確率で敵の攻撃を1ターン遅くする',
-    icon: '⏳'
+    icon: 'image/relics/time_lag.svg'
   },
   {
     key: 'rebound',
     name: 'リバウンド',
     description: '1/2の確率で落下したボールが再落下する',
-    icon: '🔄'
+    icon: 'image/relics/rebound.svg'
   },
   {
     key: 'killHeal',
     name: 'キルヒール',
     description: '敵撃破でHP10回復',
-    icon: '💖'
+    icon: 'image/relics/kill_heal.svg'
   },
   {
     key: 'damageBoost',
     name: 'ダメブースト',
     description: 'ペグ破壊時に追加ダメージ1~3',
-    icon: '💥'
+    icon: 'image/relics/damage_boost.svg'
   },
   {
     key: 'coinCharm',
     name: 'コインチャーム',
     description: '敵撃破でコイン10追加',
-    icon: '💰'
+    icon: 'image/relics/coin_charm.svg'
   }
 ];
 

--- a/style.css
+++ b/style.css
@@ -737,10 +737,7 @@ canvas {
   width: 64px;
   height: 64px;
   margin-bottom: 10px;
-  font-size: 48px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
 }
 
 #rare-reward-overlay button {

--- a/ui.js
+++ b/ui.js
@@ -49,9 +49,11 @@ export { enemyGirl };
 export function showRareRewardOverlay(reward) {
   rareRewardDesc.textContent = reward.description;
   if (reward.icon) {
-    rareRewardIcon.textContent = reward.icon;
+    rareRewardIcon.src = reward.icon;
+    rareRewardIcon.alt = reward.description;
     rareRewardIcon.style.display = 'block';
   } else {
+    rareRewardIcon.removeAttribute('src');
     rareRewardIcon.style.display = 'none';
   }
   rareRewardOverlay.style.display = 'flex';


### PR DESCRIPTION
## Summary
- show relic icons using images
- add svg assets for relic icons
- adjust rare reward overlay to render these images

## Testing
- `node --check relics.js`
- `node --check ui.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee03e398083308d64ceb0f65ff93c