### PR TITLE
feat: ボス撃破でレリック表示

### DIFF
--- a/rewards.js
+++ b/rewards.js
@@ -30,36 +30,25 @@ export const rareRewardPools = {
       }
     }
   ],
-  boss: [
-    {
-      description: '貫通ボールを入手！',
-      apply() {
-        playerState.ownedBalls.push('penetration');
-        if (!playerState.ballLevels.penetration) {
-          playerState.ballLevels.penetration = 1;
-        }
-        playerState.ammo = playerState.ownedBalls.slice();
-        playerState.shotQueue = shuffle(playerState.ammo.slice());
-      }
-    },
-    {
-      description: '50XPを獲得！',
-      apply() {
-        playerState.permXP += 50;
-        localStorage.setItem('permXP', playerState.permXP);
-      }
-    },
-    { type: 'relic' }
-  ]
 };
 
 export function getRareReward(type) {
+  if (type === 'boss') {
+    const relic = getRandomRelic();
+    return {
+      description: `${relic.name}を入手！<br>${relic.description}`,
+      icon: relic.icon,
+      apply() {
+        addRelic(relic.key);
+      }
+    };
+  }
   const pool = rareRewardPools[type] || [];
   const reward = pool[Math.floor(Math.random() * pool.length)];
   if (reward.type === 'relic') {
     const relic = getRandomRelic();
     return {
-      description: `${relic.name}を入手！`,
+      description: `${relic.name}を入手！<br>${relic.description}`,
       icon: relic.icon,
       apply() {
         addRelic(relic.key);

--- a/ui.js
+++ b/ui.js
@@ -47,7 +47,7 @@ const nodeIcons = {
 export { enemyGirl };
 
 export function showRareRewardOverlay(reward) {
-  rareRewardDesc.textContent = reward.description;
+  rareRewardDesc.innerHTML = reward.description;
   if (reward.icon) {
     rareRewardIcon.src = reward.icon;
     rareRewardIcon.alt = reward.description;


### PR DESCRIPTION
## Summary
- ボス撃破時にレリックを必ず入手して表示
- レリック名と効果をレア報酬オーバーレイで表示

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689ee6df3ac083309bb4b49350987655