### PR TITLE
Add relic display and update logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       </div>
       <div id="ammo-text"><span data-i18n="hud.ammo"></span><span id="ammo-value" class="ammo-value"></span></div>
       <div id="coin-counter"><img id="coin-icon" src="image/items/coin.png" alt="coin"><span id="coin-value">0</span></div>
+      <div id="relic-container"></div>
     </div>
     <div id="game-wrapper">
       <div id="mini-map"></div>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, firePoint, clearSimulatedPath } from './engine.js';
 import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
-import { updateAmmo, updatePlayerHP, updateCurrentBall, updateMapDisplay, showShopOverlay, updateCoins, showMapOverlay, rareRewardOverlay, rareRewardButton, xpGained } from './ui.js';
+import { updateAmmo, updatePlayerHP, updateCurrentBall, updateMapDisplay, showShopOverlay, updateCoins, showMapOverlay, rareRewardOverlay, rareRewardButton, xpGained, updateRelicIcons } from './ui.js';
 import { applyRareReward } from './rewards.js';
 import { healBallPath } from './constants.js';
 import { shuffle } from './utils.js';
@@ -162,6 +162,8 @@ window.addEventListener('DOMContentLoaded', () => {
   playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
   playerState.playerHP = playerState.playerMaxHP;
   updatePlayerHP();
+  updateCoins();
+  updateRelicIcons();
 
   const menuOverlay = document.getElementById('menu-overlay');
   const startButton = document.getElementById('start-button');
@@ -257,6 +259,7 @@ window.addEventListener('DOMContentLoaded', () => {
     rareRewardOverlay.style.display = 'none';
     if (enemyState.pendingRareReward) {
       applyRareReward(enemyState.pendingRareReward);
+      updateRelicIcons();
       enemyState.pendingRareReward = null;
     }
     if (enemyState.nodeType === 'boss') {
@@ -388,6 +391,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.coins = 0;
     localStorage.setItem('coins', playerState.coins);
     updateCoins();
+    updateRelicIcons();
     generateMap(stageSettings[worldStage]);
     updateMapDisplay(mapState);
     showMapOverlay(mapState, handleNodeSelection);
@@ -463,11 +467,13 @@ window.addEventListener('DOMContentLoaded', () => {
         playerState.coins = 0;
         localStorage.setItem('coins', playerState.coins);
         updateCoins();
+        updateRelicIcons();
     } else {
         generateMap(stageSettings[worldStage]);
         updateMapDisplay(mapState);
         document.getElementById('stage-value').textContent = enemyState.stage;
         updateCoins();
+        updateRelicIcons();
         showMapOverlay(mapState, handleNodeSelection);
     }
     });
@@ -516,6 +522,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.coins = 0;
     localStorage.setItem('coins', playerState.coins);
     updateCoins();
+    updateRelicIcons();
     generateMap(stageSettings[worldStage]);
     updateMapDisplay(mapState);
     showMapOverlay(mapState, handleNodeSelection);

--- a/style.css
+++ b/style.css
@@ -122,6 +122,15 @@ html, body {
   height: 24px;
   margin-right: 4px;
 }
+#relic-container {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+#relic-container img {
+  width: 24px;
+  height: 24px;
+}
 #shop-coin-counter {
   display: flex;
   align-items: center;

--- a/ui.js
+++ b/ui.js
@@ -5,6 +5,7 @@ import { firePoint } from './engine.js';
 import { shuffle } from './utils.js';
 import { t } from './i18n.js';
 import { getRareReward } from './rewards.js';
+import { relicList } from './relics.js';
 
 const hpFill = document.getElementById('hp-fill');
 const hpText = document.getElementById('hp-text');
@@ -14,6 +15,7 @@ const playerHpMaxText = document.getElementById('player-hp-max');
 const playerHpFill = document.getElementById('player-hp-fill');
 const ammoValue = document.getElementById('ammo-value');
 const coinValue = document.getElementById('coin-value');
+const relicContainer = document.getElementById('relic-container');
 const currentBallEl = document.getElementById('current-ball');
 const enemyGirl = document.getElementById('enemy-girl');
 const victoryOverlay = document.getElementById('victory-overlay');
@@ -168,6 +170,20 @@ export function updateCoins() {
   if (shopCoinValue) {
     shopCoinValue.textContent = playerState.coins;
   }
+}
+
+export function updateRelicIcons() {
+  if (!relicContainer) return;
+  relicContainer.innerHTML = '';
+  (playerState.relics || []).forEach(key => {
+    const relic = relicList.find(r => r.key === key);
+    if (relic && relic.icon) {
+      const img = document.createElement('img');
+      img.src = relic.icon;
+      img.alt = relic.name;
+      relicContainer.appendChild(img);
+    }
+  });
 }
 
 const shopData = {


### PR DESCRIPTION
## Summary
- show relic icons in HUD with new container and styles
- render relic icons based on player relics
- refresh relic icons on game start and after rare rewards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee691a6e48330aee12a83e18bcc70