### PR TITLE
Enable boss node selection on map

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -303,9 +303,11 @@ export function showMapOverlay(mapState, onSelect) {
       if (node.completed) {
         el.classList.add('done');
       }
+      const isBossLayer = li === mapState.layers.length - 1;
       const selectable =
         mapState.currentLayer === li &&
         (!mapState.currentNode ||
+          isBossLayer ||
           mapState.currentNode.connections.includes(ni));
       if (!selectable) {
         el.classList.add('disabled');


### PR DESCRIPTION
## Summary
- Let boss layer nodes be selected regardless of connections

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node -e "..."`

------
https://chatgpt.com/codex/tasks/task_e_689ee88c3c448330a3016454de383115