### PR TITLE
Reduce shop node spawn rate to ~10%

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,8 +118,13 @@ export function generateMap({ layerCount = 5, nodesPerLayer = 3, bossAtEnd = fal
       if (bossAtEnd && i === layerCount - 1) {
         type = 'boss';
       } else {
-        const types = ['battle', 'event', 'shop', 'elite'];
-        type = types[Math.floor(Math.random() * types.length)];
+        const r = Math.random();
+        if (r < 0.1) {
+          type = 'shop';
+        } else {
+          const types = ['battle', 'event', 'elite'];
+          type = types[Math.floor(Math.random() * types.length)];
+        }
       }
       const x = ((j + 1) * width) / (nodeCount + 1);
       const y = ((i + 1) * height) / (layerCount + 1);


### PR DESCRIPTION
## Summary
- adjust map generation to spawn shops about 10% of the time

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee98f91ac8330a4417eb7483dd38a