### PR TITLE
fix: handle single variant enemy

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -91,9 +91,13 @@ export function startStage(nodeType = 'battle') {
     variants = enemyVariants.boss;
   }
   let newIndex;
-  do {
-    newIndex = Math.floor(Math.random() * variants.length);
-  } while (newIndex === enemyState.lastVariantIndex);
+  if (variants.length <= 1) {
+    newIndex = 0;
+  } else {
+    do {
+      newIndex = Math.floor(Math.random() * variants.length);
+    } while (newIndex === enemyState.lastVariantIndex);
+  }
   const variant = variants[newIndex];
   enemyState.normalImage = variant.normalImage;
   enemyState.damageImage = variant.damageImage;


### PR DESCRIPTION
## Summary
- avoid selecting previous enemy variant when multiple variants are available
- default to first variant when only one is present

## Testing
- `node --check enemy.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689eeb23f2b8833089534c7a8889f29b