### PR TITLE
Add i18n keys for rare reward and game over overlays

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -37,6 +37,7 @@ export const translations = {
         penetration: { desc: '敵を貫通するよ♡' }
       }
     },
+    rareReward: { title: 'レア報酬ゲット！', continue: 'OK' },
     event: { title: 'ランダムイベント発生☆' },
     shop: {
       title: 'ショップだよ☆',
@@ -46,7 +47,7 @@ export const translations = {
       upgrade: '強化'
     },
     xp: { title: '経験値GET! +', continue: 'メニューへ' },
-    gameOver: { retry: 'リトライ' },
+    gameOver: { title: 'ゲームオーバー😭', retry: 'リトライ' },
     reload: { text: 'リロード中…' },
     settings: {
       title: '設定',
@@ -158,6 +159,7 @@ export const translations = {
         penetration: { desc: 'Pierces enemies♡' }
       }
     },
+    rareReward: { title: 'Rare Reward!', continue: 'OK' },
     event: { title: 'Random Event☆' },
     shop: {
       title: 'Shop Time☆',
@@ -167,7 +169,7 @@ export const translations = {
       upgrade: 'Upgrade'
     },
     xp: { title: 'XP Gained! +', continue: 'Menu' },
-    gameOver: { retry: 'Retry' },
+    gameOver: { title: 'Game Over😭', retry: 'Retry' },
     reload: { text: 'Reloading…' },
     settings: {
       title: 'Settings',

--- a/index.html
+++ b/index.html
@@ -84,10 +84,10 @@
       </div>
     </div>
     <div id="rare-reward-overlay">
-      <h2>レア報酬ゲット！</h2>
+      <h2 data-i18n="rareReward.title"></h2>
       <img id="rare-reward-icon" alt="rare icon" />
       <p id="rare-reward-desc"></p>
-      <button id="rare-reward-continue">OK</button>
+      <button id="rare-reward-continue" data-i18n="rareReward.continue"></button>
     </div>
     <div id="event-overlay">
       <h2 id="event-title" data-i18n="event.title"></h2>
@@ -105,7 +105,7 @@
       <button id="xp-continue-button" data-i18n="xp.continue"></button>
     </div>
     <div id="game-over-overlay">
-      <h2>gameover😭</h2>
+      <h2 data-i18n="gameOver.title"></h2>
       <button id="game-over-retry-button" data-i18n="gameOver.retry"></button>
     </div>
     <div id="reload-overlay" data-i18n="reload.text"></div>


### PR DESCRIPTION
## Summary
- add `data-i18n` attributes for rare reward and game over overlays
- provide Japanese/English translations for new keys
- cover these elements with existing `setLanguage` updater

## Testing
- `node --input-type=module <<'NODE'
import { setLanguage } from './i18n.js';
const elements = [
  { textContent: '', getAttribute: () => 'rareReward.title' },
  { textContent: '', getAttribute: () => 'rareReward.continue' },
  { textContent: '', getAttribute: () => 'gameOver.title' }
];
global.document = {
  documentElement: {},
  querySelectorAll: () => elements
};
global.localStorage = { setItem: () => {} };
setLanguage('en');
console.log(elements.map(e => e.textContent).join('|'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689eec2dbeac8330aa4e37b49ed41503