### PR TITLE
Remove map node debug click listener

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -313,9 +313,6 @@ export function showMapOverlay(mapState, onSelect) {
         el.classList.add('disabled');
       }
       area.appendChild(el);
-      el.addEventListener('click', () => {
-        console.log('map node clicked', li, ni);
-      });
     });
   });
 


### PR DESCRIPTION
## Summary
- remove debug click listener from map nodes in map overlay
- rely on overlay-level handler for node selection

## Testing
- `node --check ui.js`


------
https://chatgpt.com/codex/tasks/task_e_689eed28297c8330bb50dc41127e1aed