### PR TITLE
戦闘・イベント優先のマップ生成調整

### DIFF
--- a/main.js
+++ b/main.js
@@ -121,8 +121,14 @@ export function generateMap({ layerCount = 5, nodesPerLayer = 3, bossAtEnd = fal
         if (r < 0.1) {
           type = 'shop';
         } else {
-          const types = ['battle', 'event', 'elite'];
-          type = types[Math.floor(Math.random() * types.length)];
+          const r2 = Math.random();
+          if (r2 < 0.6) {
+            type = 'battle';
+          } else if (r2 < 0.9) {
+            type = 'event';
+          } else {
+            type = 'elite';
+          }
         }
       }
       const x = ((j + 1) * width) / (nodeCount + 1);


### PR DESCRIPTION
## 概要
- マップノード生成時の戦闘・イベント・エリートの確率を60/30/10に変更

## テスト
- `node --input-type=module -e "…"` で10000回シミュレートし分布を確認


------
https://chatgpt.com/codex/tasks/task_e_689eee6986948330a34748c6a9ac183f