### PR TITLE
Initialize next ball selection at stage start and ensure default shot

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -113,8 +113,8 @@ export function startStage(nodeType = 'battle') {
   playerState.currentShotType = null;
   playerState.ammo = playerState.ownedBalls.slice();
   playerState.shotQueue = shuffle(playerState.ammo.slice());
+  enemyState.selectNextBall();
   enemyState.updateHPBar();
-  uiSelectNextBall(firePoint);
   enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
   document.getElementById('stage-value').textContent = enemyState.stage;
   updateAttackCountdown(enemyState);

--- a/main.js
+++ b/main.js
@@ -561,11 +561,20 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   handleShoot = function handleShoot(e) {
+    if (
+      playerState.currentBalls.length > 0 ||
+      enemyState.gameOver ||
+      playerState.reloading ||
+      isAnyOverlayVisible()
+    ) return;
+
     if (!playerState.nextBall) {
       enemyState.selectNextBall();
-      if (!playerState.nextBall) return;
+      if (!playerState.nextBall) {
+        playerState.nextBall = playerState.ownedBalls[0] || 'normal';
+      }
     }
-    if (playerState.currentBalls.length > 0 || enemyState.gameOver || playerState.reloading || isAnyOverlayVisible()) return;
+
     if (playerState.ammo.length <= 0) {
       startReload();
       return;


### PR DESCRIPTION
## Summary
- Call `enemyState.selectNextBall()` right after replenishing ammo in `startStage` to initialize `playerState.nextBall`
- Refactor `handleShoot` to guard early and fall back to a default ball if `nextBall` is missing

## Testing
- `node --check enemy.js main.js`


------
https://chatgpt.com/codex/tasks/task_e_689eef3be4dc8330a8a20ef4b18073d0