### PR TITLE
Use ball names in power stone choice

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,7 +43,7 @@ const randomEvents = [
       const types = [...new Set(playerState.ownedBalls)];
       const opts = types.map(type => ({
         type,
-        label: t('events.powerStone.choiceLabel').replace('{type}', t(`balls.${type}.full`)),
+        label: t('events.powerStone.choiceLabel').replace('{type}', t(`balls.${type}.name`)),
         apply() {
           playerState.ballLevels[type] = (playerState.ballLevels[type] || 1) + 1;
           updateAmmo();


### PR DESCRIPTION
## Summary
- Use ball name in Power Stone choice label

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "import('./i18n.js').then(...)"`


------
https://chatgpt.com/codex/tasks/task_e_689ef28b99e883308e574f035407c127