### PR TITLE
Use getComputedStyle for overlay visibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -228,7 +228,9 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   const isAnyOverlayVisible = () =>
-    overlays.some(o => o.classList.contains('show') || o.style.display !== 'none');
+    overlays.some(o =>
+      o.classList.contains('show') || getComputedStyle(o).display !== 'none'
+    );
 
   const showOverlay = (overlay) => {
     overlay.classList.add('show');


### PR DESCRIPTION
## Summary
- use `getComputedStyle` when checking overlay visibility

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx playwright --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ef33e3a1c8330bb3563549c3718f4