### PR TITLE
Use getComputedStyle for overlay visibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -228,9 +228,10 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   const isAnyOverlayVisible = () =>
-    overlays.some(o =>
-      o.classList.contains('show') || getComputedStyle(o).display !== 'none'
-    );
+    overlays.some((o) => {
+      const display = window.getComputedStyle(o).display;
+      return o.classList.contains('show') || display !== 'none';
+    });
 
   const showOverlay = (overlay) => {
     overlay.classList.add('show');


### PR DESCRIPTION
## Summary
- ensure overlay visibility uses computed styles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689ef3ff7f008330997e29e60c4dde5b