### PR TITLE
Show enemy attack countdown and damage in HUD

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -17,7 +17,9 @@ export const translations = {
     hud: {
       hp: 'HP: ',
       ammo: '弾: ',
-      stage: 'ステージ: '
+      stage: 'ステージ: ',
+      untilAttack: '攻撃まで',
+      damage: 'ダメージ'
     },
     balls: {
       normal: { name: 'ノーマル', full: 'ノーマルボール' },
@@ -139,7 +141,9 @@ export const translations = {
     hud: {
       hp: 'HP: ',
       ammo: 'Ammo: ',
-      stage: 'Stage: '
+      stage: 'Stage: ',
+      untilAttack: 'Until Attack',
+      damage: 'Damage'
     },
     balls: {
       normal: { name: 'Normal', full: 'Normal Ball' },

--- a/style.css
+++ b/style.css
@@ -248,6 +248,8 @@ html, body {
   padding: 4px 8px;
   border: 2px solid #ff69b4;
   border-radius: 4px;
+  display: inline-block;
+  white-space: nowrap;
 }
 canvas {
   display: block;

--- a/ui.js
+++ b/ui.js
@@ -66,7 +66,7 @@ export { rareRewardOverlay, rareRewardButton };
 export function updateAttackCountdown(enemyState) {
   const timer = document.getElementById('enemy-attack-timer');
   if (timer) {
-    timer.textContent = enemyState.attackCountdown;
+    timer.textContent = `${t('hud.untilAttack')}: ${enemyState.attackCountdown} / ${t('hud.damage')}: ${enemyState.attackDamage}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- display attack countdown and enemy damage together in HUD
- add i18n keys for attack timer text
- tweak attack timer styling to handle longer text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef5b082cc833096fcdc1656f5d05f