### PR TITLE
feat: fully heal player after boss defeat

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -91,7 +91,10 @@ export function updateHPBar(enemyState) {
     updateCoins();
     document.getElementById('reward-coin-value').textContent = coinsEarned;
     localStorage.setItem('coins', playerState.coins);
-    if (playerState.relics && playerState.relics.includes('killHeal')) {
+    if (enemyState.nodeType === 'boss') {
+      playerState.playerHP = playerState.playerMaxHP;
+      updatePlayerHP();
+    } else if (playerState.relics && playerState.relics.includes('killHeal')) {
       playerState.playerHP = Math.min(playerState.playerMaxHP, playerState.playerHP + 10);
       updatePlayerHP();
     }


### PR DESCRIPTION
## Summary
- Fully restore player HP after defeating a boss
- Prioritize full heal over killHeal relic effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef6828b088330948205a3fe7cab26