### PR TITLE
Ensure rare reward button rebinds each overlay

### DIFF
--- a/main.js
+++ b/main.js
@@ -268,7 +268,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function onRareRewardClick(e) {
+  export function onRareRewardClick(e) {
     e.stopPropagation();
     rareRewardButton.disabled = true;
     rareRewardOverlay.style.display = 'none';
@@ -288,10 +288,6 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function setupRareRewardButton() {
-    rareRewardButton.disabled = false;
-    rareRewardButton.addEventListener('click', onRareRewardClick, { once: true });
-  }
 
   function triggerRandomEvent(onDone) {
     const shopChance = 0.05;
@@ -358,7 +354,6 @@ window.addEventListener('DOMContentLoaded', () => {
       showMapOverlay(mapState, handleNodeSelection);
     }
     setupRewardButtons();
-    setupRareRewardButton();
   }
 
   function handleNodeSelection(index) {
@@ -515,7 +510,6 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 
   setupRewardButtons();
-  setupRareRewardButton();
 
   gameOverRetry.addEventListener('click', (e) => {
     e.stopPropagation();

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,5 @@
 import { playerState } from './player.js';
-import { handleShoot } from './main.js';
+import { handleShoot, onRareRewardClick } from './main.js';
 import { healBallPath } from './constants.js';
 import { firePoint } from './engine.js';
 import { shuffle } from './utils.js';
@@ -58,6 +58,8 @@ export function showRareRewardOverlay(reward) {
     rareRewardIcon.removeAttribute('src');
     rareRewardIcon.style.display = 'none';
   }
+  rareRewardButton.disabled = false;
+  rareRewardButton.addEventListener('click', onRareRewardClick, { once: true });
   rareRewardOverlay.style.display = 'flex';
 }
 


### PR DESCRIPTION
## Summary
- reset and re-enable rare reward button each time overlay appears
- export click handler and remove redundant setup logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7e37fd883309cc023e048e49faa