### PR TITLE
feat: soften stage 1 boss

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -34,7 +34,7 @@ export const enemyVariants = {
       normalImage: 'image/enemies/enemy3_normal.png',
       damageImage: 'image/enemies/enemy3_damage.png',
       defeatImages: ['image/enemies/enemy3_defeat.png', 'image/enemies/enemy3_defeat2.png', 'image/enemies/enemy3_defeat3.png'],
-      hpMultiplier: 5,
+      hpMultiplier: 4,
       attackDamage: 20
     }
   ]


### PR DESCRIPTION
## Summary
- lower boss HP multiplier from 5 to 4 to make stage 1 boss easier

## Testing
- `node --check enemy.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef8a471b08330a0563e8a1c9d915f