### PR TITLE
Add glowing aura for bosses

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -84,6 +84,11 @@ export const enemyState = {
 
 export function startStage(nodeType = 'battle') {
   enemyState.nodeType = nodeType;
+  const enemyGirl = document.getElementById('enemy-girl');
+  enemyGirl.classList.remove('boss-aura');
+  if (enemyState.nodeType === 'boss') {
+    enemyGirl.classList.add('boss-aura');
+  }
   let variants = enemyVariants.normal;
   if (nodeType === 'elite') {
     variants = enemyVariants.elite;

--- a/style.css
+++ b/style.css
@@ -235,6 +235,21 @@ html, body {
 #enemy-girl {
   width: 400px;
 }
+
+.boss-aura {
+  animation: boss-glow 1.5s ease-in-out infinite;
+  box-shadow: 0 0 20px rgba(255, 0, 0, 0.8), 0 0 40px rgba(255, 0, 0, 0.6);
+  border-radius: 50%;
+}
+
+@keyframes boss-glow {
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(255, 0, 0, 0.8), 0 0 40px rgba(255, 0, 0, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(255, 0, 0, 1), 0 0 60px rgba(255, 0, 0, 0.8);
+  }
+}
 #enemy-image-wrapper {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- Style boss enemies with a pulsating aura animation
- Toggle boss aura when stage type changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef96186988330b07f1bda37023849