### PR TITLE
ページ読み込み後にbodyが表示されない不具合の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,11 @@
       document.body.insertAdjacentHTML('beforeend', '<p>Matter.js の読み込みに失敗しました。</p>');
     }
   </script>
+  <script>
+    window.addEventListener('load', () => {
+      document.body.style.display = 'block';
+    });
+  </script>
   <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ページのロード完了時に`body`を表示するスクリプトを追加
- これにより、スクリプト読み込み時に画面が真っ白になる問題を解消

## Testing
- `npm test` *(package.jsonが無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689efe81a6048330b2a5b26d0cb30d92