### PR TITLE
Populate version history dynamically

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -268,5 +268,24 @@ export function setLanguage(lang) {
       el.textContent = txt;
     }
   });
+  const historyEl = document.getElementById('version-history');
+  if (historyEl) {
+    const history = translations[currentLang].history;
+    const titleEl = historyEl.querySelector('h3');
+    const listEl = historyEl.querySelector('ul');
+    if (history) {
+      if (titleEl) titleEl.textContent = history.title || '';
+      if (listEl) {
+        listEl.innerHTML = '';
+        Object.keys(history)
+          .filter(k => k !== 'title')
+          .forEach(k => {
+            const li = document.createElement('li');
+            li.textContent = history[k];
+            listEl.appendChild(li);
+          });
+      }
+    }
+  }
   localStorage.setItem('lang', lang);
 }

--- a/index.html
+++ b/index.html
@@ -135,27 +135,8 @@
   </div>
 
   <div id="version-history">
-    <h3 data-i18n="history.title"></h3>
-    <ul>
-      <li data-i18n="history.v1_6"></li>
-      <li data-i18n="history.v1_5"></li>
-      <li data-i18n="history.v1_4"></li>
-      <li data-i18n="history.v1_3"></li>
-      <li data-i18n="history.v1_2"></li>
-      <li data-i18n="history.v1_1"></li>
-      <li data-i18n="history.v1_0"></li>
-      <li data-i18n="history.v0_9_2"></li>
-      <li data-i18n="history.v0_9_1"></li>
-      <li data-i18n="history.v0_9"></li>
-      <li data-i18n="history.v0_8"></li>
-      <li data-i18n="history.v0_7"></li>
-      <li data-i18n="history.v0_6"></li>
-      <li data-i18n="history.v0_5"></li>
-      <li data-i18n="history.v0_4"></li>
-      <li data-i18n="history.v0_3"></li>
-      <li data-i18n="history.v0_2"></li>
-      <li data-i18n="history.v0_1"></li>
-    </ul>
+    <h3></h3>
+    <ul></ul>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>


### PR DESCRIPTION
## Summary
- build version history list from translation data so entries always appear
- simplify markup by generating items with setLanguage

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f01f53fa48330af49cb6659494baf