### PR TITLE
fix: export rare reward handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,6 +95,7 @@ const randomEvents = [
 ];
 
 export let handleShoot;
+export let onRareRewardClick;
 
 export const mapState = { layers: [], currentLayer: 0, currentNode: null, path: [] };
 
@@ -268,7 +269,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  export function onRareRewardClick(e) {
+  onRareRewardClick = function onRareRewardClick(e) {
     e.stopPropagation();
     rareRewardButton.disabled = true;
     rareRewardOverlay.style.display = 'none';
@@ -286,7 +287,7 @@ window.addEventListener('DOMContentLoaded', () => {
     } else {
       proceedToNextLayer();
     }
-  }
+  };
 
 
   function triggerRandomEvent(onDone) {


### PR DESCRIPTION
## Summary
- declare `onRareRewardClick` as an exported variable and assign inside the DOMContentLoaded block
- avoid `export` statements inside functions to prevent syntax error

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f05c8da808330bf0a77d34683765e