### PR TITLE
feat: add noscript and error fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,10 @@
   <title>Peggy Girls</title>
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
+  <noscript><style>body.hidden{display:block;}</style></noscript>
 </head>
-<body style="display: none;">
+<body class="hidden">
+  <noscript><p>JavaScriptが無効だと遊べないよ〜✨</p></noscript>
   <div id="container">
     <div id="menu-overlay">
       <div id="main-menu">
@@ -141,14 +143,26 @@
 
   <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
   <script>
-    if (!window.Matter) {
-      document.body.insertAdjacentHTML('beforeend', '<p>Matter.js の読み込みに失敗しました。</p>');
+    function showError(message) {
+      document.body.classList.remove('hidden');
+      document.body.insertAdjacentHTML('beforeend', `<p>${message}</p>`);
     }
-  </script>
-  <script>
+
+    if (!window.Matter) {
+      showError('Matter.js の読み込みに失敗しました。');
+    }
+
     window.addEventListener('load', () => {
-      document.body.style.display = 'block';
+      try {
+        document.body.classList.remove('hidden');
+      } catch (e) {
+        showError('読み込みエラーが発生しちゃった…');
+      }
     });
+
+    window.addEventListener('error', () => {
+      showError('なんかエラーが起きちゃったみたい…');
+    }, { once: true });
   </script>
   <script type="module" src="main.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -9,6 +9,9 @@ html, body {
   align-items: center;
   justify-content: flex-start;
 }
+.hidden {
+  display: none;
+}
 #container {
   display: flex;
 }


### PR DESCRIPTION
## Summary
- replace inline body display control with `.hidden` class
- add `<noscript>` fallback and JS error handling for load failures

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e9792ac8330b2e80ffd6eed3a72