### PR TITLE
feat: make layout responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=1280,user-scalable=yes" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Peggy Girls</title>
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">

--- a/style.css
+++ b/style.css
@@ -898,3 +898,21 @@ canvas {
   stroke-width: 4px;
 }
 
+/* Responsive layout adjustments */
+@media (max-width: 1280px) {
+  #container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  #game-wrapper,
+  #side-panel {
+    width: 100%;
+  }
+
+  #side-panel {
+    border-left: none;
+    border-top: 8px solid #ff69b4;
+  }
+}
+


### PR DESCRIPTION
## Summary
- use device width viewport for proper scaling
- stack panels vertically on narrow screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2dc240b483308ad58a8b1389c0d1