### PR TITLE
fix: mark map overlay touch handler as passive

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -363,7 +363,7 @@ export function showMapOverlay(mapState, onSelect) {
     onSelect && onSelect(idx);
   };
   mapOverlay.addEventListener('click', mapOverlayHandler);
-  mapOverlay.addEventListener('touchstart', mapOverlayHandler);
+  mapOverlay.addEventListener('touchstart', mapOverlayHandler, { passive: true });
   mapOverlay.style.display = 'flex';
 }
 


### PR DESCRIPTION
## Summary
- mark map overlay touchstart listener as passive to address non-passive event warning

## Testing
- `npm test` *(fails: package.json not found)*
- `npm run lint` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f322c7d00833088a2b7680234c152