### PR TITLE
initEngineでRenderとRunnerを起動するよう修正

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -36,6 +36,12 @@ function createGhostEngine() {
 }
 
 export function initEngine() {
+  if (render) {
+    Render.stop(render);
+  }
+  if (runner) {
+    Runner.stop(runner);
+  }
   engine = Engine.create();
   world = engine.world;
   render = Render.create({
@@ -43,9 +49,9 @@ export function initEngine() {
     engine,
     options: { width, height, wireframes: false, background: '#fff0f5' }
   });
-  // Render.run(render);
+  Render.run(render);
   runner = Runner.create();
-  // Runner.run(runner, engine);
+  Runner.run(runner, engine);
 
   Events.on(engine, 'beforeUpdate', () => {
     playerState.currentBalls.forEach(ball => {


### PR DESCRIPTION
## Summary
- initEngineでRender.runとRunner.runを呼び出すようにしてMatterのレンダリングとランナーループを開始
- 再初期化時に既存ループを停止して二重起動を防止

## Testing
- `npm test` (package.jsonがなく失敗)
- ブラウザ動作確認は外部CDNへのアクセスが403で実行不可

------
https://chatgpt.com/codex/tasks/task_e_689f3b34e06c8330aa1413c976297a98