### PR TITLE
fix: コンテナ高さとレスポンシブ調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ html, body {
 }
 #container {
   display: flex;
+  height: 700px;
 }
 #game-wrapper {
   position: relative;
@@ -903,11 +904,13 @@ canvas {
   #container {
     flex-direction: column;
     align-items: stretch;
+    height: auto;
   }
 
   #game-wrapper,
   #side-panel {
     width: 100%;
+    height: 700px;
   }
 
   #side-panel {


### PR DESCRIPTION
## Summary
- コンテナに高さ700pxを設定してレイアウトを固定
- レスポンシブ時は高さを自動調整しつつ各パネルに700pxを適用

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_689f3c2a3b6c833092e7892a8f6d7d5e