### PR TITLE
Fix Matter.js loading by using CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     <ul></ul>
   </div>
 
-  <script src="libs/matter.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
   <script>
     function showError(message) {
       document.body.classList.remove('hidden');

--- a/libs/matter.min.js
+++ b/libs/matter.min.js
@@ -1,1 +1,0 @@
-// TODO: Add Matter.js v0.19.0 library file. Download failed due to network restrictions.


### PR DESCRIPTION
## Summary
- replace missing local Matter.js with CDN link
- remove empty library placeholder

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689f3df846ec8330a1381279d24a9bf4