### PR TITLE
Game Over リトライでメニューを表示

### DIFF
--- a/main.js
+++ b/main.js
@@ -536,9 +536,7 @@ window.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('coins', playerState.coins);
     updateCoins();
     updateRelicIcons();
-    generateMap(stageSettings[worldStage]);
-    updateMapDisplay(mapState);
-    showMapOverlay(mapState, handleNodeSelection);
+    showOverlay(menuOverlay);
   });
 
   const aimSvg = document.getElementById('aim-svg');


### PR DESCRIPTION
## Summary
- Retrying after Game Over now returns to the main menu instead of regenerating the map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f423ced8883309331d7590f867a6c