### PR TITLE
プレイヤーステータスの表示を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       </div>
       <div id="ammo-text"><span data-i18n="hud.ammo"></span><span id="ammo-value" class="ammo-value"></span></div>
       <div id="coin-counter"><img id="coin-icon" src="image/items/coin.png" alt="coin"><span id="coin-value">0</span></div>
+      <div id="player-status">ATK Lv: <span id="player-atk-level">0</span> / HP Lv: <span id="player-hp-level">0</span></div>
       <div id="relic-container"></div>
     </div>
     <div id="game-wrapper">

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, clearS
 import { firePoint } from './engine.js';
 import { playerState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
-import { updateAmmo, updatePlayerHP, updateCurrentBall, updateMapDisplay, showShopOverlay, updateCoins, showMapOverlay, rareRewardOverlay, rareRewardButton, xpGained, updateRelicIcons } from './ui.js';
+import { updateAmmo, updatePlayerHP, updateCurrentBall, updateMapDisplay, showShopOverlay, updateCoins, showMapOverlay, rareRewardOverlay, rareRewardButton, xpGained, updateRelicIcons, updatePlayerStatus } from './ui.js';
 import { applyRareReward } from './rewards.js';
 import { healBallPath } from './constants.js';
 import { shuffle } from './utils.js';
@@ -199,6 +199,7 @@ window.addEventListener('DOMContentLoaded', () => {
   updatePlayerHP();
   updateCoins();
   updateRelicIcons();
+  updatePlayerStatus();
 
   const menuOverlay = document.getElementById('menu-overlay');
   const startButton = document.getElementById('start-button');
@@ -406,6 +407,7 @@ window.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('coins', playerState.coins);
     updateCoins();
     updateRelicIcons();
+    updatePlayerStatus();
     generateMap(stageSettings[worldStage]);
     updateMapDisplay(mapState);
     showMapOverlay(mapState, handleNodeSelection);
@@ -436,6 +438,7 @@ window.addEventListener('DOMContentLoaded', () => {
       playerState.playerHP = playerState.playerMaxHP;
       updatePlayerHP();
       xpDisplay.textContent = playerState.permXP;
+      updatePlayerStatus();
     }
   });
 
@@ -447,6 +450,7 @@ window.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('permXP', playerState.permXP);
       localStorage.setItem('atkLevel', playerState.atkLevel);
       xpDisplay.textContent = playerState.permXP;
+      updatePlayerStatus();
     }
   });
 
@@ -475,6 +479,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.nextBall = null;
     playerState.reloading = false;
     updatePlayerHP();
+    updatePlayerStatus();
     enemyState.selectNextBall();
     if (worldStage > 2) {
         showOverlay(menuOverlay);
@@ -482,12 +487,14 @@ window.addEventListener('DOMContentLoaded', () => {
         localStorage.setItem('coins', playerState.coins);
         updateCoins();
         updateRelicIcons();
+        updatePlayerStatus();
     } else {
         generateMap(stageSettings[worldStage]);
         updateMapDisplay(mapState);
         document.getElementById('stage-value').textContent = enemyState.stage;
         updateCoins();
         updateRelicIcons();
+        updatePlayerStatus();
         showMapOverlay(mapState, handleNodeSelection);
     }
     });
@@ -531,11 +538,13 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.nextBall = null;
     playerState.reloading = false;
     updatePlayerHP();
+    updatePlayerStatus();
     enemyState.selectNextBall();
     playerState.coins = 0;
     localStorage.setItem('coins', playerState.coins);
     updateCoins();
     updateRelicIcons();
+    updatePlayerStatus();
     showOverlay(menuOverlay);
   });
 

--- a/style.css
+++ b/style.css
@@ -121,6 +121,12 @@ html, body {
   height: 24px;
   margin-right: 4px;
 }
+#player-status {
+  font-size: 14px;
+  font-weight: bold;
+  color: #ff1493;
+  margin-top: 4px;
+}
 #relic-container {
   display: flex;
   gap: 4px;

--- a/ui.js
+++ b/ui.js
@@ -16,6 +16,8 @@ const playerHpFill = document.getElementById('player-hp-fill');
 const ammoValue = document.getElementById('ammo-value');
 const coinValue = document.getElementById('coin-value');
 const relicContainer = document.getElementById('relic-container');
+const playerAtkLevel = document.getElementById('player-atk-level');
+const playerHpLevel = document.getElementById('player-hp-level');
 const currentBallEl = document.getElementById('current-ball');
 const enemyGirl = document.getElementById('enemy-girl');
 const victoryOverlay = document.getElementById('victory-overlay');
@@ -174,6 +176,15 @@ export function updateCoins() {
   const shopCoinValue = document.getElementById('shop-coin-value');
   if (shopCoinValue) {
     shopCoinValue.textContent = playerState.coins;
+  }
+}
+
+export function updatePlayerStatus() {
+  if (playerAtkLevel) {
+    playerAtkLevel.textContent = playerState.atkLevel;
+  }
+  if (playerHpLevel) {
+    playerHpLevel.textContent = playerState.hpLevel;
   }
 }
 


### PR DESCRIPTION
## Summary
- HUDにATK/HPレベルの表示を追加
- `updatePlayerStatus`でプレイヤーステータスを更新
- ゲーム開始やアップグレード時にステータス更新を呼び出し

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f430fdd3c83309dbc292f45e8bbee