### PR TITLE
Remove HUD stage display

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -121,7 +121,6 @@ export function startStage(nodeType = 'battle') {
   enemyState.selectNextBall();
   enemyState.updateHPBar();
   enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
-  document.getElementById('stage-value').textContent = enemyState.stage;
   updateAttackCountdown(enemyState);
   enemyState.lastVariantIndex = newIndex;
 }

--- a/i18n.js
+++ b/i18n.js
@@ -17,7 +17,6 @@ export const translations = {
     hud: {
       hp: 'HP: ',
       ammo: '弾: ',
-      stage: 'ステージ: ',
       untilAttack: '攻撃まで',
       damage: 'ダメージ'
     },
@@ -142,7 +141,6 @@ export const translations = {
     hud: {
       hp: 'HP: ',
       ammo: 'Ammo: ',
-      stage: 'Stage: ',
       untilAttack: 'Until Attack',
       damage: 'Damage'
     },

--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
       <div id="current-ball"></div>
     </div>
     <div id="side-panel">
-      <div id="stage-text"><span data-i18n="hud.stage"></span><span id="stage-value">1</span></div>
       <div class="hp-container">
         <div class="hp-value" id="hp-display">200 / 200</div>
         <div id="hp-bar">

--- a/main.js
+++ b/main.js
@@ -485,7 +485,6 @@ window.addEventListener('DOMContentLoaded', () => {
     } else {
         generateMap(stageSettings[worldStage]);
         updateMapDisplay(mapState);
-        document.getElementById('stage-value').textContent = enemyState.stage;
         updateCoins();
         updateRelicIcons();
         showMapOverlay(mapState, handleNodeSelection);


### PR DESCRIPTION
## Summary
- remove stage text element from side panel
- drop unused stage-value updates
- clean up hud.stage translations

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689fd46927e48330ba08bf7cf0a9e575