### PR TITLE
feat: persist ball inventory across stages

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 import { initEngine, drawSimulatedPath, shootBall, setupCollisionHandler, clearSimulatedPath } from './engine.js';
 import { firePoint } from './engine.js';
-import { playerState } from './player.js';
+import { playerState, saveBallState } from './player.js';
 import { enemyState, startStage } from './enemy.js';
 import { updateAmmo, updatePlayerHP, updateCurrentBall, updateMapDisplay, showShopOverlay, updateCoins, showMapOverlay, rareRewardOverlay, rareRewardButton, xpGained, updateRelicIcons } from './ui.js';
 import { applyRareReward } from './rewards.js';
@@ -48,6 +48,7 @@ const randomEvents = [
           playerState.ballLevels[type] = (playerState.ballLevels[type] || 1) + 1;
           updateAmmo();
           updateCurrentBall(firePoint);
+          saveBallState();
         },
         result: t('events.powerStone.result').replace('{type}', t(`balls.${type}.full`))
       }));
@@ -82,6 +83,7 @@ const randomEvents = [
           playerState.ammo = playerState.ownedBalls.slice();
           playerState.shotQueue = shuffle(playerState.ammo.slice());
           enemyState.selectNextBall();
+          saveBallState();
         },
         resultKey: 'events.foundBall.results.take'
       },
@@ -192,10 +194,11 @@ window.addEventListener('DOMContentLoaded', () => {
   initEngine();
   setupCollisionHandler();
 
-  playerState.ownedBalls = ['normal', 'normal', 'normal'];
-  playerState.ballLevels = { normal: 1 };
   playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
   playerState.playerHP = playerState.playerMaxHP;
+  playerState.ammo = playerState.ownedBalls.slice();
+  playerState.shotQueue = shuffle(playerState.ammo.slice());
+  saveBallState();
   updatePlayerHP();
   updateCoins();
   updateRelicIcons();
@@ -280,6 +283,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     playerState.ammo = playerState.ownedBalls.slice();
     playerState.shotQueue = shuffle(playerState.ammo.slice());
+    saveBallState();
     enemyState.selectNextBall();
     hideOverlay(rewardOverlay);
     proceedToNextLayer();
@@ -464,8 +468,6 @@ window.addEventListener('DOMContentLoaded', () => {
       mapState.currentLayer = 0;
       mapState.currentNode = null;
       mapState.path = [];
-    playerState.ownedBalls = ['normal', 'normal', 'normal'];
-    playerState.ballLevels = { normal: 1 };
     playerState.playerMaxHP = 100 + playerState.hpLevel * 10;
     playerState.playerHP = playerState.playerMaxHP;
     playerState.ammo = playerState.ownedBalls.slice();
@@ -476,6 +478,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.reloading = false;
     updatePlayerHP();
     enemyState.selectNextBall();
+    saveBallState();
     if (worldStage > 2) {
         showOverlay(menuOverlay);
         playerState.coins = 0;
@@ -531,6 +534,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playerState.reloading = false;
     updatePlayerHP();
     enemyState.selectNextBall();
+    saveBallState();
     playerState.coins = 0;
     localStorage.setItem('coins', playerState.coins);
     updateCoins();

--- a/player.js
+++ b/player.js
@@ -5,8 +5,8 @@ export const playerState = {
   playerMaxHP: 100,
   ammo: [],
   shotQueue: [],
-  ownedBalls: [],
-  ballLevels: { normal: 1 },
+  ownedBalls: JSON.parse(localStorage.getItem('ownedBalls') || '["normal","normal","normal"]'),
+  ballLevels: JSON.parse(localStorage.getItem('ballLevels') || '{"normal":1}'),
   nextBall: null,
   reloading: false,
   permXP: parseInt(localStorage.getItem('permXP') || '0', 10),
@@ -15,3 +15,8 @@ export const playerState = {
   coins: parseInt(localStorage.getItem('coins') || '0', 10),
   relics: []
 };
+
+export function saveBallState() {
+  localStorage.setItem('ownedBalls', JSON.stringify(playerState.ownedBalls));
+  localStorage.setItem('ballLevels', JSON.stringify(playerState.ballLevels));
+}

--- a/rewards.js
+++ b/rewards.js
@@ -1,4 +1,4 @@
-import { playerState } from './player.js';
+import { playerState, saveBallState } from './player.js';
 import { shuffle } from './utils.js';
 import { addRelic, getRandomRelic } from './relics.js';
 
@@ -13,6 +13,7 @@ export const rareRewardPools = {
         }
         playerState.ammo = playerState.ownedBalls.slice();
         playerState.shotQueue = shuffle(playerState.ammo.slice());
+        saveBallState();
       }
     },
     {

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-import { playerState } from './player.js';
+import { playerState, saveBallState } from './player.js';
 import { handleShoot, onRareRewardClick } from './main.js';
 import { healBallPath } from './constants.js';
 import { firePoint } from './engine.js';
@@ -263,6 +263,7 @@ export function showShopOverlay(onDone) {
     }
     playerState.ammo = playerState.ownedBalls.slice();
     playerState.shotQueue = shuffle(playerState.ammo.slice());
+    saveBallState();
     localStorage.setItem('coins', playerState.coins);
     shopOptions.removeEventListener('click', handleClick);
     shopOverlay.classList.remove('show');


### PR DESCRIPTION
## Summary
- load and save owned ball data via localStorage
- avoid resetting ball inventory on stage clear and persist after shop/reward actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd881029c8330abe1f4635f657a8e