### PR TITLE
Reset ball state when starting run

### DIFF
--- a/main.js
+++ b/main.js
@@ -410,6 +410,15 @@ window.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('coins', playerState.coins);
     updateCoins();
     updateRelicIcons();
+    playerState.ownedBalls = ['normal', 'normal', 'normal'];
+    playerState.ballLevels = { normal: 1 };
+    playerState.ammo = playerState.ownedBalls.slice();
+    playerState.shotQueue = shuffle(playerState.ammo.slice());
+    playerState.currentBalls = [];
+    playerState.currentShotType = null;
+    playerState.nextBall = null;
+    playerState.reloading = false;
+    saveBallState();
     generateMap(stageSettings[worldStage]);
     updateMapDisplay(mapState);
     showMapOverlay(mapState, handleNodeSelection);


### PR DESCRIPTION
## Summary
- Reset player ball-related state when clicking the start button to ensure fresh runs

## Testing
- `npm test` (fails: ENOENT, no package.json)


------
https://chatgpt.com/codex/tasks/task_e_689fe00b08b083308516ffa176215c2f