### PR TITLE
Center enemy image wrapper and hide overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -258,10 +258,12 @@ html, body {
 #enemy-image-wrapper {
   position: relative;
   box-sizing: border-box;
-  /* border: 8px solid #ff69b4; */
-  /* border-radius: 8px; */
-  /* padding: 4px; */
-  overflow: visible;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 8px;
+  overflow: hidden;
 }
 #enemy-attack-timer {
   position: absolute;


### PR DESCRIPTION
## Summary
- center and clip enemy image wrapper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe82155348330ba41cd60a4c8b54f