### PR TITLE
Reset relics after finishing game

### DIFF
--- a/main.js
+++ b/main.js
@@ -490,6 +490,7 @@ window.addEventListener('DOMContentLoaded', () => {
     saveBallState();
     if (worldStage > 2) {
         showOverlay(menuOverlay);
+        playerState.relics = [];
         playerState.coins = 0;
         localStorage.setItem('coins', playerState.coins);
         updateCoins();


### PR DESCRIPTION
## Summary
- Clear relics when returning to menu after final stage so players start fresh on new run

## Testing
- `node main.js` *(fails: ReferenceError: localStorage is not defined)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a18c85ef488330baee3d3619338d62