### PR TITLE
Add game clear overlay

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -49,6 +49,7 @@ export const translations = {
     },
     xp: { title: '経験値GET! +', continue: 'メニューへ' },
     gameOver: { title: 'ゲームオーバー😭', retry: 'リトライ' },
+    gameClear: { title: 'ゲームクリア✨', menu: 'タイトルへ' },
     reload: { text: 'リロード中…' },
     settings: {
       title: '設定',
@@ -174,6 +175,7 @@ export const translations = {
     },
     xp: { title: 'XP Gained! +', continue: 'Menu' },
     gameOver: { title: 'Game Over😭', retry: 'Retry' },
+    gameClear: { title: 'Game Clear✨', menu: 'Back to Title' },
     reload: { text: 'Reloading…' },
     settings: {
       title: 'Settings',

--- a/index.html
+++ b/index.html
@@ -109,6 +109,10 @@
       <h2 data-i18n="gameOver.title"></h2>
       <button id="game-over-retry-button" data-i18n="gameOver.retry"></button>
     </div>
+    <div id="game-clear-overlay">
+      <h2 data-i18n="gameClear.title"></h2>
+      <button id="game-clear-menu" data-i18n="gameClear.menu"></button>
+    </div>
     <div id="reload-overlay" data-i18n="reload.text"></div>
     <div id="settings-overlay">
       <h2 id="settings-title" data-i18n="settings.title"></h2>

--- a/main.js
+++ b/main.js
@@ -222,6 +222,8 @@ window.addEventListener('DOMContentLoaded', () => {
     const eventOptions = document.getElementById('event-options');
     const gameOverOverlay = document.getElementById('game-over-overlay');
     const gameOverRetry = document.getElementById('game-over-retry-button');
+    const gameClearOverlay = document.getElementById('game-clear-overlay');
+    const gameClearMenu = document.getElementById('game-clear-menu');
     const reloadOverlay = document.getElementById('reload-overlay');
     const victoryOverlay = document.getElementById('victory-overlay');
     const shopOverlay = document.getElementById('shop-overlay');
@@ -240,6 +242,7 @@ window.addEventListener('DOMContentLoaded', () => {
     rareRewardOverlay,
     eventOverlay,
     gameOverOverlay,
+    gameClearOverlay,
     reloadOverlay,
       victoryOverlay,
       shopOverlay,
@@ -489,7 +492,7 @@ window.addEventListener('DOMContentLoaded', () => {
     enemyState.selectNextBall();
     saveBallState();
     if (worldStage > 2) {
-        showOverlay(menuOverlay);
+        showOverlay(gameClearOverlay);
         playerState.relics = [];
         playerState.coins = 0;
         localStorage.setItem('coins', playerState.coins);
@@ -502,6 +505,12 @@ window.addEventListener('DOMContentLoaded', () => {
         updateRelicIcons();
         showMapOverlay(mapState, handleNodeSelection);
     }
+    });
+
+    gameClearMenu.addEventListener('click', (e) => {
+      e.stopPropagation();
+      hideOverlay(gameClearOverlay);
+      showOverlay(menuOverlay);
     });
 
     creditBtn.addEventListener('click', (e) => {

--- a/style.css
+++ b/style.css
@@ -503,6 +503,34 @@ canvas {
   color: #ff1493;
   cursor: pointer;
 }
+#game-clear-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+  text-align: center;
+}
+#game-clear-overlay h2 {
+  font-size: 48px;
+  margin: 0 0 20px;
+}
+#game-clear-overlay button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 20px;
+  border: 2px solid #ff69b4;
+  background: #fff;
+  color: #ff1493;
+  cursor: pointer;
+}
 #reload-overlay {
   position: absolute;
   top: 0;
@@ -741,6 +769,7 @@ canvas {
 #reward-overlay.show,
 #event-overlay.show,
 #game-over-overlay.show,
+#game-clear-overlay.show,
 #reload-overlay.show,
 #victory-overlay.show,
 #shop-overlay.show {


### PR DESCRIPTION
## Summary
- add game clear overlay with translations and styling
- show game clear screen after final stage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a18d9d6b7c8330bbf500501f6a9f70