### PR TITLE
feat: add treasure chest random event

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -99,6 +99,17 @@ export const translations = {
           take: 'ノーマルボールゲットだよ☆',
           skip: 'スルーしたよ〜'
         }
+      },
+      treasure: {
+        text: 'キラキラの宝箱を見つけたよ☆',
+        choices: {
+          open: '開ける💎',
+          leave: 'そのままにする'
+        },
+        results: {
+          open: '30コインをゲットしたよ💰',
+          leave: '何も起きなかった〜'
+        }
       }
     },
       history: {
@@ -224,6 +235,17 @@ export const translations = {
         results: {
           take: 'Got a normal ball☆',
           skip: 'Skipped it~'
+        }
+      },
+      treasure: {
+        text: 'You spot a shiny treasure chest☆',
+        choices: {
+          open: 'Open it💎',
+          leave: 'Leave it'
+        },
+        results: {
+          open: 'Got 30 coins💰',
+          leave: 'Nothing happened~'
         }
       }
     },

--- a/main.js
+++ b/main.js
@@ -73,11 +73,11 @@ const randomEvents = [
       }
     ]
   },
-  {
-    textKey: 'events.foundBall.text',
-    choices: [
-      {
-        labelKey: 'events.foundBall.choices.take',
+    {
+      textKey: 'events.foundBall.text',
+      choices: [
+        {
+          labelKey: 'events.foundBall.choices.take',
         apply() {
           playerState.ownedBalls.push('normal');
           playerState.ammo = playerState.ownedBalls.slice();
@@ -91,6 +91,25 @@ const randomEvents = [
         labelKey: 'events.foundBall.choices.skip',
         apply() {},
         resultKey: 'events.foundBall.results.skip'
+      }
+    ]
+  }
+  ,
+  {
+    textKey: 'events.treasure.text',
+    choices: [
+      {
+        labelKey: 'events.treasure.choices.open',
+        apply() {
+          playerState.coins += 30;
+          updateCoins();
+        },
+        resultKey: 'events.treasure.results.open'
+      },
+      {
+        labelKey: 'events.treasure.choices.leave',
+        apply() {},
+        resultKey: 'events.treasure.results.leave'
       }
     ]
   }


### PR DESCRIPTION
## Summary
- add new treasure chest random event that grants 30 coins
- provide JP/EN translations for treasure chest event

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a18ea775288330af8b7e8475beb849