### PR TITLE
Add pause and speed controls to HUD

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -88,6 +88,24 @@ export function initEngine() {
   createGhostEngine();
 }
 
+export function pauseRunner() {
+  if (runner) {
+    Runner.stop(runner);
+  }
+}
+
+export function resumeRunner() {
+  if (runner) {
+    Runner.run(runner, engine);
+  }
+}
+
+export function setTimeScale(scale) {
+  if (engine) {
+    engine.timing.timeScale = scale;
+  }
+}
+
 export function generatePegs(count, isBoss = enemyState.nodeType === 'boss') {
   initialPegCount = count;
   pegs.forEach((p) => World.remove(world, p));

--- a/i18n.js
+++ b/i18n.js
@@ -18,7 +18,12 @@ export const translations = {
       hp: 'HP: ',
       ammo: '弾: ',
       untilAttack: '攻撃まで',
-      damage: 'ダメージ'
+      damage: 'ダメージ',
+      pause: 'ポーズ',
+      resume: '再開',
+      speed: '速度',
+      speed1: '1x',
+      speed2: '2x'
     },
     balls: {
       normal: { name: 'ノーマル', full: 'ノーマルボール' },
@@ -155,7 +160,12 @@ export const translations = {
       hp: 'HP: ',
       ammo: 'Ammo: ',
       untilAttack: 'Until Attack',
-      damage: 'Damage'
+      damage: 'Damage',
+      pause: 'Pause',
+      resume: 'Resume',
+      speed: 'Speed',
+      speed1: '1x',
+      speed2: '2x'
     },
     balls: {
       normal: { name: 'Normal', full: 'Normal Ball' },

--- a/index.html
+++ b/index.html
@@ -35,6 +35,14 @@
       <div id="ammo-text"><span data-i18n="hud.ammo"></span><span id="ammo-value" class="ammo-value"></span></div>
       <div id="coin-counter"><img id="coin-icon" src="image/items/coin.png" alt="coin"><span id="coin-value">0</span></div>
       <div id="relic-container"></div>
+      <div id="hud-controls">
+        <button id="pause-button" data-i18n="hud.pause"></button>
+        <label for="speed-select" data-i18n="hud.speed"></label>
+        <select id="speed-select">
+          <option value="1" data-i18n="hud.speed1"></option>
+          <option value="2" data-i18n="hud.speed2"></option>
+        </select>
+      </div>
     </div>
     <div id="game-wrapper">
       <div id="mini-map"></div>

--- a/ui.js
+++ b/ui.js
@@ -1,7 +1,7 @@
 import { playerState, saveBallState } from './player.js';
 import { handleShoot, onRareRewardClick } from './main.js';
 import { healBallPath } from './constants.js';
-import { firePoint } from './engine.js';
+import { firePoint, pauseRunner, resumeRunner, setTimeScale } from './engine.js';
 import { shuffle } from './utils.js';
 import { t } from './i18n.js';
 import { getRareReward } from './rewards.js';
@@ -16,6 +16,8 @@ const playerHpFill = document.getElementById('player-hp-fill');
 const ammoValue = document.getElementById('ammo-value');
 const coinValue = document.getElementById('coin-value');
 const relicContainer = document.getElementById('relic-container');
+const pauseButton = document.getElementById('pause-button');
+const speedSelect = document.getElementById('speed-select');
 const currentBallEl = document.getElementById('current-ball');
 const enemyGirl = document.getElementById('enemy-girl');
 const victoryOverlay = document.getElementById('victory-overlay');
@@ -31,6 +33,27 @@ const rareRewardOverlay = document.getElementById('rare-reward-overlay');
 const rareRewardDesc = document.getElementById('rare-reward-desc');
 const rareRewardIcon = document.getElementById('rare-reward-icon');
 const rareRewardButton = document.getElementById('rare-reward-continue');
+
+let isPaused = false;
+if (pauseButton) {
+  pauseButton.addEventListener('click', () => {
+    if (isPaused) {
+      resumeRunner();
+      isPaused = false;
+      pauseButton.dataset.i18n = 'hud.pause';
+    } else {
+      pauseRunner();
+      isPaused = true;
+      pauseButton.dataset.i18n = 'hud.resume';
+    }
+    pauseButton.textContent = t(pauseButton.dataset.i18n);
+  });
+}
+if (speedSelect) {
+  speedSelect.addEventListener('change', (e) => {
+    setTimeScale(parseFloat(e.target.value));
+  });
+}
 
 const mapOverlay = document.createElement('div');
 mapOverlay.id = 'map-overlay';


### PR DESCRIPTION
## Summary
- add pause button and speed dropdown to HUD
- handle pause state and speed change in UI and engine
- add i18n strings for new controls

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a191c672d083308bfd1b7f5f76c189