### PR TITLE
feat: add relic shop

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -50,7 +50,9 @@ export const translations = {
       close: 'やめる',
       buy: '購入',
       sell: '削除',
-      upgrade: '強化'
+      upgrade: '強化',
+      relic: 'レリック',
+      buyRelic: '入手'
     },
     xp: { title: '経験値GET! +', continue: 'メニューへ' },
     gameOver: { title: 'ゲームオーバー😭', retry: 'リトライ' },
@@ -192,7 +194,9 @@ export const translations = {
       close: 'Leave',
       buy: 'Buy',
       sell: 'Remove',
-      upgrade: 'Upgrade'
+      upgrade: 'Upgrade',
+      relic: 'Relic',
+      buyRelic: 'Buy'
     },
     xp: { title: 'XP Gained! +', continue: 'Menu' },
     gameOver: { title: 'Game Over😭', retry: 'Retry' },


### PR DESCRIPTION
## Summary
- display random relics in shop with prices and descriptions
- support purchasing relics and updating coin/relic display
- add translations for relic shop UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1930ac8ec8330992661dc11eb1f26