### PR TITLE
feat: add skill tree with persistent skills

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -4,6 +4,7 @@ export const translations = {
       title: 'Peggy Girls',
       start: 'スタート',
       upgrade: 'アップグレード',
+      skills: 'スキルツリー',
       reset: '進捗リセット',
       settings: '設定',
       credit: 'クレジット'
@@ -13,6 +14,24 @@ export const translations = {
       hp: 'HPアップ(+10) 10XP',
       atk: '攻撃アップ(+10%) 10XP',
       back: '戻る'
+    },
+    skillTree: {
+      title: 'スキルツリー',
+      back: '戻る',
+      unlock: '{cost}で習得',
+      unlocked: '習得済み',
+      skills: {
+        doubleShot: {
+          name: 'ダブルショット',
+          desc: '2連続で撃てるよ☆',
+          cost: '15XP'
+        },
+        maxHp: {
+          name: 'HPアップ',
+          desc: '最大HPが20増えるよ♪',
+          cost: '10XP'
+        }
+      }
     },
     hud: {
       hp: 'HP: ',
@@ -148,6 +167,7 @@ export const translations = {
       title: 'Peggy Girls',
       start: 'Start',
       upgrade: 'Upgrade',
+      skills: 'Skill Tree',
       reset: 'Reset Progress',
       settings: 'Settings',
       credit: 'Credits'
@@ -157,6 +177,24 @@ export const translations = {
       hp: 'HP Up (+10) 10XP',
       atk: 'ATK Up (+10%) 10XP',
       back: 'Back'
+    },
+    skillTree: {
+      title: 'Skill Tree',
+      back: 'Back',
+      unlock: 'Unlock for {cost}',
+      unlocked: 'Unlocked',
+      skills: {
+        doubleShot: {
+          name: 'Double Shot',
+          desc: 'Shoot twice in a row♪',
+          cost: '15XP'
+        },
+        maxHp: {
+          name: 'HP Up',
+          desc: 'Increase max HP by 20☆',
+          cost: '10XP'
+        }
+      }
     },
     hud: {
       hp: 'HP: ',

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <h1 id="game-title" data-i18n="menu.title"></h1>
         <button id="start-button" class="menu-option" data-i18n="menu.start"></button>
         <button id="upgrade-menu-button" class="menu-option" data-i18n="menu.upgrade"></button>
+        <button id="skill-tree-button" class="menu-option" data-i18n="menu.skills"></button>
         <button id="reset-progress" class="menu-option" data-i18n="menu.reset"></button>
         <button id="settings-button" class="menu-option" data-i18n="menu.settings"></button>
       </div>
@@ -24,6 +25,12 @@
         <button id="upgrade-hp" data-i18n="upgrade.hp"></button>
         <button id="upgrade-atk" data-i18n="upgrade.atk"></button>
         <button id="upgrade-back" data-i18n="upgrade.back"></button>
+      </div>
+      <div id="skill-tree">
+        <h2 data-i18n="skillTree.title"></h2>
+        <div id="skill-xp-display"><span data-i18n="upgrade.xp"></span><span id="skill-xp-value">0</span></div>
+        <div id="skill-list"></div>
+        <button id="skill-tree-back" data-i18n="skillTree.back"></button>
       </div>
       <button id="credit-button" data-i18n="menu.credit"></button>
     </div>

--- a/player.js
+++ b/player.js
@@ -1,3 +1,8 @@
+export const skillTree = [
+  { key: 'doubleShot', cost: 15 },
+  { key: 'maxHp', cost: 10 }
+];
+
 export const playerState = {
   currentBalls: [],
   currentShotType: null,
@@ -13,10 +18,15 @@ export const playerState = {
   hpLevel: parseInt(localStorage.getItem('hpLevel') || '0', 10),
   atkLevel: parseInt(localStorage.getItem('atkLevel') || '0', 10),
   coins: parseInt(localStorage.getItem('coins') || '0', 10),
-  relics: []
+  relics: [],
+  skills: JSON.parse(localStorage.getItem('skills') || '[]')
 };
 
 export function saveBallState() {
   localStorage.setItem('ownedBalls', JSON.stringify(playerState.ownedBalls));
   localStorage.setItem('ballLevels', JSON.stringify(playerState.ballLevels));
+}
+
+export function saveSkillState() {
+  localStorage.setItem('skills', JSON.stringify(playerState.skills));
 }

--- a/rewards.js
+++ b/rewards.js
@@ -1,4 +1,4 @@
-import { playerState, saveBallState } from './player.js';
+import { playerState, saveBallState, saveSkillState } from './player.js';
 import { shuffle } from './utils.js';
 import { addRelic, getRandomRelic } from './relics.js';
 
@@ -28,6 +28,7 @@ export const rareRewardPools = {
       apply() {
         playerState.skills = playerState.skills || [];
         playerState.skills.push('doubleShot');
+        saveSkillState();
       }
     }
   ],

--- a/style.css
+++ b/style.css
@@ -739,6 +739,34 @@ canvas {
     border-radius: 8px;
   }
 
+#skill-tree {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}
+
+  #skill-tree button {
+    margin: 5px 0;
+    padding: 10px 20px;
+    border: 2px solid #ff69b4;
+    background: #fff;
+    color: #ff1493;
+    cursor: pointer;
+    border-radius: 8px;
+  }
+
+#skill-xp-display {
+  font-size: 24px;
+  color: #ff1493;
+  margin-bottom: 20px;
+}
+
+.skill-item {
+  margin: 5px 0;
+  text-align: center;
+}
+
   #credit-button {
     position: absolute;
     bottom: 10px;


### PR DESCRIPTION
## Summary
- add skill tree data and persistence on player state
- implement skill tree UI with unlocking and double shot/hp boost skills
- apply skill effects during gameplay and save progress

## Testing
- `node --check player.js ui.js main.js rewards.js i18n.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a193f55a408330858ba29db65399ba