### PR TITLE
feat: add gallery translations

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -84,6 +84,12 @@ export const translations = {
       options: { ja: '日本語', en: 'English' },
       close: '閉じる'
     },
+    gallery: {
+      title: 'ギャラリー',
+      next: '次へ',
+      prev: '前へ',
+      close: '閉じる'
+    },
     credit: { close: '閉じる' },
     progress: { randomEvent: 'ランダムイベント' },
     events: {
@@ -246,6 +252,12 @@ export const translations = {
       title: 'Settings',
       language: 'Language',
       options: { ja: 'Japanese', en: 'English' },
+      close: 'Close'
+    },
+    gallery: {
+      title: 'Gallery',
+      next: 'Next',
+      prev: 'Prev',
       close: 'Close'
     },
     credit: { close: 'Close' },

--- a/index.html
+++ b/index.html
@@ -154,12 +154,13 @@
       <button id="credit-close" data-i18n="credit.close"></button>
     </div>
     <div id="gallery-overlay">
+      <h2 id="gallery-title" data-i18n="gallery.title"></h2>
       <div id="gallery-controls">
-        <button id="gallery-prev"></button>
+        <button id="gallery-prev" data-i18n="gallery.prev"></button>
         <img id="gallery-image" src="" alt="gallery">
-        <button id="gallery-next"></button>
+        <button id="gallery-next" data-i18n="gallery.next"></button>
       </div>
-      <button id="gallery-close"></button>
+      <button id="gallery-close" data-i18n="gallery.close"></button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add gallery translation strings for Japanese and English
- hook up gallery overlay elements to translation system

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a02466ec8330850d3f0b073df9a4