### PR TITLE
Adjust menu buttons for smaller screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -706,14 +706,15 @@ canvas {
 }
 
 .menu-option {
-  padding: 20px 40px;
-  font-size: 24px;
+  padding: 10px 20px;
+  font-size: 20px;
   border: 2px solid #ff69b4;
   background: #fff;
   color: #ff1493;
   cursor: pointer;
   border-radius: 8px;
   margin: 10px 0;
+  max-width: 100%;
 }
 
 #xp-display {


### PR DESCRIPTION
## Summary
- reduce menu button padding and font size
- ensure menu buttons don't overflow horizontally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a117cb288330883e6cfef84ce294