### PR TITLE
chore: remove player image from gallery

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,6 @@ const ballImageMap = {
 };
 
 const galleryImages = [
-  './image/player/hero1.png',
   './image/enemies/enemy_normal.png',
   './image/enemies/enemy2_normal.png',
   './image/enemies/enemy3_normal.png',


### PR DESCRIPTION
## Summary
- remove player image from gallery list so it doesn't show in gallery

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/kawaii_peg/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a1a1fd9c84833097b56221c7bf72af