### PR TITLE
Fix gallery overlay image dimensions

### DIFF
--- a/style.css
+++ b/style.css
@@ -947,8 +947,9 @@ canvas {
   }
 
   #gallery-image {
-    max-width: 80%;
-    max-height: 80%;
+    width: 880px;
+    height: 700px;
+    object-fit: contain;
   }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- Set fixed dimensions for #gallery-image (880x700) with object-fit contain to match game viewport

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a28110dc833098e0be2059a930c8