### PR TITLE
feat: make gallery image responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -947,8 +947,10 @@ canvas {
   }
 
   #gallery-image {
-    width: 880px;
-    height: 700px;
+    max-width: 80vw;
+    max-height: 80vh;
+    width: auto;
+    height: auto;
     object-fit: contain;
   }
 


### PR DESCRIPTION
## Summary
- make gallery overlay image resize to viewport

## Testing
- `npm test` *(fails: no package.json)*
- `python - <<'PY'
import webbrowser, pathlib
path = pathlib.Path('index.html').resolve().as_uri()
webbrowser.open(path)
print('Opened', path)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a1a5627cf883308f56b32104cca87c