### PR TITLE
Fix gallery overlay scrolling and image height

### DIFF
--- a/style.css
+++ b/style.css
@@ -892,6 +892,8 @@ canvas {
     z-index: 60;
     opacity: 0;
     transition: opacity .3s;
+    overflow: auto;
+    padding-bottom: 20px;
   }
 
   #credit-overlay.show {
@@ -948,7 +950,7 @@ canvas {
 
   #gallery-image {
     max-width: 80vw;
-    max-height: 80vh;
+    max-height: calc(100% - 120px);
     width: auto;
     height: auto;
     object-fit: contain;


### PR DESCRIPTION
## Summary
- Add overflow and padding to gallery overlay for better scroll and spacing
- Reserve space for overlay title and close button by reducing gallery image max height

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a7313fdc8330aa9515941d2ae3ab