### PR TITLE
撃破後にアップグレードカード表示を追加＆ステージHPスケーリングを変更

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -1,6 +1,6 @@
 import { playerState } from './player.js';
 import { firePoint, generatePegs } from './engine.js';
-import { updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, selectNextBall as uiSelectNextBall, updateAttackCountdown } from './ui.js';
+import { updateHPBar, updatePlayerHP, flashEnemyDamage, showDamageOverlay, shakeContainer, selectNextBall as uiSelectNextBall, updateAttackCountdown, updateStageDisplay } from './ui.js';
 import { shuffle } from './utils.js';
 
 export const enemyVariants = {
@@ -117,7 +117,8 @@ export function startStage(nodeType = 'battle') {
   enemyState.attackDamage = variant.attackDamage;
   document.getElementById('enemy-girl').src = enemyState.normalImage;
   generatePegs(50 + (enemyState.stage - 1) * 10, enemyState.nodeType === 'boss');
-  enemyState.maxEnemyHP = (100 + (enemyState.stage - 1) * 100) * variant.hpMultiplier;
+  const baseEnemyHP = Math.floor(100 * Math.pow(1.8, enemyState.stage - 1));
+  enemyState.maxEnemyHP = Math.floor(baseEnemyHP * variant.hpMultiplier);
   enemyState.enemyHP = enemyState.maxEnemyHP;
   enemyState.pendingDamage = 0;
   enemyState.pendingRareReward = null;
@@ -127,6 +128,7 @@ export function startStage(nodeType = 'battle') {
   playerState.shotQueue = shuffle(playerState.ammo.slice());
   enemyState.selectNextBall();
   enemyState.updateHPBar();
+  updateStageDisplay(enemyState.stage);
   enemyState.attackCountdown = Math.floor(Math.random() * 3) + 1;
   updateAttackCountdown(enemyState);
   enemyState.lastVariantIndex = newIndex;

--- a/index.html
+++ b/index.html
@@ -68,10 +68,17 @@
       <div id="enemy-image-wrapper">
         <img id="enemy-girl" src="" alt="enemy">
         <div id="enemy-attack-timer"></div>
+        <div id="stage-display">Stage: <span id="stage-value">1</span></div>
       </div>
     </div>
     <div id="victory-overlay">
       <img id="victory-img" src="image/enemies/enemy_defeat.png" alt="victory">
+    </div>
+
+    <div id="upgrade-card-overlay">
+      <h2>Upgrade Card</h2>
+      <p>1枚選んで強化しよう！</p>
+      <div id="upgrade-card-options"></div>
     </div>
     <div id="reward-overlay">
       <h2 id="result-title" data-i18n="reward.title"></h2>

--- a/player.js
+++ b/player.js
@@ -17,6 +17,13 @@ export const playerState = {
   permXP: parseInt(localStorage.getItem('permXP') || '0', 10),
   hpLevel: parseInt(localStorage.getItem('hpLevel') || '0', 10),
   atkLevel: parseInt(localStorage.getItem('atkLevel') || '0', 10),
+  baseDamage: parseInt(localStorage.getItem('baseDamage') || '0', 10),
+  comboBonus: parseInt(localStorage.getItem('comboBonus') || '0', 10),
+  restitution: parseFloat(localStorage.getItem('restitution') || '0'),
+  shotPower: parseInt(localStorage.getItem('shotPower') || '0', 10),
+  multiballCount: parseInt(localStorage.getItem('multiballCount') || '0', 10),
+  critRate: parseFloat(localStorage.getItem('critRate') || '0'),
+  critMultiplier: parseFloat(localStorage.getItem('critMultiplier') || '0'),
   coins: parseInt(localStorage.getItem('coins') || '0', 10),
   relics: [],
   skills: JSON.parse(localStorage.getItem('skills') || '[]')

--- a/style.css
+++ b/style.css
@@ -1039,3 +1039,44 @@ canvas {
   }
 }
 
+
+
+#stage-display {
+  margin-top: 8px;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+}
+
+#upgrade-card-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255,255,255,0.95);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 31;
+}
+
+#upgrade-card-options {
+  display: flex;
+  gap: 16px;
+}
+
+.upgrade-card-button {
+  min-width: 180px;
+  padding: 12px;
+  border: 2px solid #ff69b4;
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+}
+
+#upgrade-card-overlay.show {
+  display: flex;
+}

--- a/ui.js
+++ b/ui.js
@@ -3,6 +3,7 @@ import { handleShoot, onRareRewardClick, applySkillEffects } from './main.js';
 import { healBallPath } from './constants.js';
 import { firePoint, pauseRunner, resumeRunner, setTimeScale } from './engine.js';
 import { shuffle } from './utils.js';
+import { startStage } from './enemy.js';
 import { t } from './i18n.js';
 import { getRareReward } from './rewards.js';
 import { relicList, addRelic } from './relics.js';
@@ -33,6 +34,9 @@ const rareRewardOverlay = document.getElementById('rare-reward-overlay');
 const rareRewardDesc = document.getElementById('rare-reward-desc');
 const rareRewardIcon = document.getElementById('rare-reward-icon');
 const rareRewardButton = document.getElementById('rare-reward-continue');
+const upgradeCardOverlay = document.getElementById('upgrade-card-overlay');
+const upgradeCardOptions = document.getElementById('upgrade-card-options');
+const stageValue = document.getElementById('stage-value');
 
 const mainMenu = document.getElementById('main-menu');
 const skillTreeButton = document.getElementById('skill-tree-button');
@@ -149,6 +153,41 @@ export function showRareRewardOverlay(reward) {
 
 export { rareRewardOverlay, rareRewardButton };
 
+const upgradeCardPool = [
+  { key: 'baseDamage', label: 'Base Damage +5', apply: () => { playerState.baseDamage += 5; localStorage.setItem('baseDamage', playerState.baseDamage); } },
+  { key: 'comboBonus', label: 'Combo Bonus +10', apply: () => { playerState.comboBonus += 10; localStorage.setItem('comboBonus', playerState.comboBonus); } },
+  { key: 'restitution', label: 'Restitution +0.05', apply: () => { playerState.restitution = +(playerState.restitution + 0.05).toFixed(2); localStorage.setItem('restitution', playerState.restitution); } },
+  { key: 'shotPower', label: 'Shot Power +1', apply: () => { playerState.shotPower += 1; localStorage.setItem('shotPower', playerState.shotPower); } },
+  { key: 'multiballCount', label: 'Multiball +1', apply: () => { playerState.multiballCount += 1; localStorage.setItem('multiballCount', playerState.multiballCount); } },
+  { key: 'critRate', label: 'Crit Rate +2%', apply: () => { playerState.critRate = +(playerState.critRate + 0.02).toFixed(2); localStorage.setItem('critRate', playerState.critRate); } },
+  { key: 'critMultiplier', label: 'Crit Dmg +0.1', apply: () => { playerState.critMultiplier = +(playerState.critMultiplier + 0.1).toFixed(2); localStorage.setItem('critMultiplier', playerState.critMultiplier); } }
+];
+
+function showUpgradeCardOverlay(enemyState, onDone) {
+  const cards = shuffle(upgradeCardPool.slice()).slice(0, 3);
+  upgradeCardOptions.innerHTML = '';
+  cards.forEach((card) => {
+    const btn = document.createElement('button');
+    btn.className = 'upgrade-card-button';
+    btn.textContent = card.label;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      card.apply();
+      upgradeCardOverlay.classList.remove('show');
+      enemyState.stage += 1;
+      startStage(enemyState.nodeType);
+      if (onDone) onDone();
+    }, { once: true });
+    upgradeCardOptions.appendChild(btn);
+  });
+  upgradeCardOverlay.classList.add('show');
+}
+
+export function updateStageDisplay(stage) {
+  if (stageValue) stageValue.textContent = stage;
+}
+
+
 export function updateAttackCountdown(enemyState) {
   const timer = document.getElementById('enemy-attack-timer');
   if (timer) {
@@ -192,13 +231,15 @@ export function updateHPBar(enemyState) {
         victoryOverlay.classList.remove('show');
         enemyState.gameOver = false;
         document.getElementById('aim-svg').addEventListener('click', handleShoot);
-        if (enemyState.nodeType === 'elite' || enemyState.nodeType === 'boss') {
-          const reward = getRareReward(enemyState.nodeType);
-          enemyState.pendingRareReward = reward;
-          showRareRewardOverlay(reward);
-        } else {
-          rewardOverlay.classList.add('show');
-        }
+        showUpgradeCardOverlay(enemyState, () => {
+          if (enemyState.nodeType === 'elite' || enemyState.nodeType === 'boss') {
+            const reward = getRareReward(enemyState.nodeType);
+            enemyState.pendingRareReward = reward;
+            showRareRewardOverlay(reward);
+          } else {
+            rewardOverlay.classList.add('show');
+          }
+        });
       };
       victoryOverlay.addEventListener('click', (e) => { e.stopPropagation(); proceed(); }, { once: true });
     }, 200);


### PR DESCRIPTION
### Motivation
- 撃破フローを分岐して既存の報酬UIの前にプレイヤー強化を挟み、即時の成長と次ステージ移行を可能にするためだよ〜✨。 
- ステージ進行に合わせたHPの指数成長にして難度調整を分かりやすくしたかったの。 
- 現在の進行を見やすくするためにサイドパネルにステージ表示を追加したよ。

### Description
- `index.html` に `#upgrade-card-overlay` と `#stage-display` を追加し、`style.css` に関連スタイルを追加したよ。 
- `ui.js` にカード候補プール（`baseDamage`, `comboBonus`, `restitution`, `shotPower`, `multiballCount`, `critRate`, `critMultiplier`）、`showUpgradeCardOverlay`、`updateStageDisplay` を実装し、撃破時の処理をカード表示経由に差し替えたよ。 
- `playerState` に新しい強化ステータスを永続化するフィールドを追加して `localStorage` から復元するようにしたよ（`player.js`）。 
- `enemy.js` の `startStage` を修正して基礎HPを `Math.floor(100 * Math.pow(1.8, stage - 1))` で算出し既存の `hpMultiplier` を乗算、ステージ開始時に `updateStageDisplay` を呼ぶようにしたよ。 
- カード選択時に選択効果を適用して `enemyState.stage += 1` した後に `startStage(enemyState.nodeType)` を呼んで次ステージを開始するフローを導入したよ。

### Testing
- `node --check ui.js` を実行して問題なし。 
- `node --check enemy.js` を実行して問題なし。 
- `node --check main.js` を実行して問題なし。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b43a63dc83308116f99a608bf36c)