### PR TITLE
`playerState.multiballCount`でマルチボールの拡散発射を追加したよ〜

### DIFF
--- a/main.js
+++ b/main.js
@@ -672,10 +672,19 @@ window.addEventListener('DOMContentLoaded', () => {
     const dx = e.clientX - rect.left - firePoint.x;
     const dy = e.clientY - rect.top - firePoint.y;
     const angle = Math.atan2(dy, dx);
+    const fireMultiball = (baseAngle, ballType) => {
+      const count = Math.max(1, playerState.multiballCount || 1);
+      const step = 0.06;
+      const center = (count - 1) / 2;
+      for (let i = 0; i < count; i += 1) {
+        const offset = (i - center) * step;
+        shootBall(baseAngle + offset, ballType);
+      }
+    };
     const type = playerState.nextBall;
     const idx = playerState.ammo.indexOf(type);
     if (idx !== -1) playerState.ammo.splice(idx, 1);
-    shootBall(angle, type);
+    fireMultiball(angle, type);
     clearTimeout(aimTimer);
     clearSimulatedPath();
     if (playerState.skills && playerState.skills.includes('doubleShot') && playerState.ammo.length > 0) {
@@ -684,7 +693,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const idx2 = playerState.ammo.indexOf(type2);
       if (idx2 !== -1) playerState.ammo.splice(idx2, 1);
       setTimeout(() => {
-        shootBall(angle, type2);
+        fireMultiball(angle, type2);
         enemyState.selectNextBall();
       }, 100);
     } else {

--- a/player.js
+++ b/player.js
@@ -21,7 +21,7 @@ export const playerState = {
   comboBonus: parseInt(localStorage.getItem('comboBonus') || '0', 10),
   restitution: parseFloat(localStorage.getItem('restitution') || '0'),
   shotPower: parseInt(localStorage.getItem('shotPower') || '0', 10),
-  multiballCount: parseInt(localStorage.getItem('multiballCount') || '0', 10),
+  multiballCount: Math.max(1, parseInt(localStorage.getItem('multiballCount') || '1', 10)),
   critRate: parseFloat(localStorage.getItem('critRate') || '0'),
   critMultiplier: parseFloat(localStorage.getItem('critMultiplier') || '0'),
   coins: parseInt(localStorage.getItem('coins') || '0', 10),


### PR DESCRIPTION
### Motivation
- 発射側で複数弾をまとめて出せるようにして、カード強化の`multiballCount`を有効活用するための変更だよ。

### Description
- `playerState.multiballCount`の初期値を最低`1`にクランプして保存値が`0`でも動くようにした（`player.js`で`Math.max(1, ...)`に変更）。
- `handleShoot`側に`fireMultiball`を追加して、呼び出し時に`playerState.multiballCount`個を`±0.06rad`刻みの中心対称オフセットで`shootBall(angle, type)`をループ呼び出しするようにした（`main.js`）。
- `engine.js`の`shootBall`は単発生成のまま変更せず、ループ処理は呼び出し元（`handleShoot`）で行う設計を維持した。
- 既存の`ballsCleared`トリガ（`playerState.currentBalls.length === 0`）やカードUIの`Multiball +1`経路はそのまま有効で、挙動を壊してないよ。

### Testing
- 自動チェックで`node --check main.js`を実行して成功したよ。
- 自動チェックで`node --check player.js`を実行して成功したよ。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b5fef74c83308284e08458651223)