### PR TITLE
クリティカル／コンボ演出と波紋爆発、可変スクリーンシェイクを追加

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,4 +1,4 @@
-import { showBombExplosion, showDamageText, showHealSpark, showHitSpark, launchHeartAttack, updateCoins, updateShotStats } from './ui.js';
+import { showBombExplosion, showComboBanner, showCriticalText, showDamageText, showHealSpark, showHitSpark, launchHeartAttack, screenShake, updateCoins, updateShotStats } from './ui.js';
 import { updateCurrentBall } from './ui.js';
 import { updateAttackCountdown } from './ui.js';
 import { playerState } from './player.js';
@@ -336,13 +336,19 @@ export function shootBall(angle, type) {
 function calculateHitDamage(baseDamage, ball, pegType = 'normal') {
   const comboDamage = baseDamage * (1 + shotCombo * comboBonus);
   let damage = comboDamage * (ball.damageMultiplier || 1) * (1 + playerState.atkLevel * 0.1);
+  let isCritical = false;
   if (pegType === 'critical') {
     damage *= 2;
+    isCritical = true;
+  }
+  if (Math.random() < playerState.critRate) {
+    damage *= playerState.critMultiplier;
+    isCritical = true;
   }
   if (playerState.relics && playerState.relics.includes('damageBoost')) {
     damage += Math.floor(Math.random() * 3) + 1;
   }
-  return damage;
+  return { damage, isCritical };
 }
 
 function spawnSplitBalls(peg, ball) {
@@ -389,11 +395,13 @@ function handlePegHit(peg, ball) {
 function applyHit(baseDamage, ball, peg, pegType = 'normal') {
   currentShotHits++;
   shotCombo++;
-  const damage = calculateHitDamage(baseDamage, ball, pegType);
+  const { damage, isCritical } = calculateHitDamage(baseDamage, ball, pegType);
   enemyState.pendingDamage += damage;
   shotTotalDamage += damage;
   updateShotStats(shotCombo, shotTotalDamage);
   showDamageText(Math.round(peg.position.x), Math.round(peg.position.y), '+' + Math.round(enemyState.pendingDamage), ball.ballType === 'heal');
+  if (isCritical) showCriticalText(Math.round(peg.position.x), Math.round(peg.position.y));
+  if (shotCombo >= 10) showComboBanner(shotCombo);
   if (ball.ballType === 'heal') {
     showHealSpark(peg.position.x, peg.position.y);
   } else {
@@ -482,6 +490,9 @@ export function setupCollisionHandler() {
               enemyState.flashEnemyDamage();
               showDamageText(Math.round(x), Math.round(y), '-' + Math.round(totalDamage));
               showHitSpark(x, y);
+              if (totalDamage >= enemyState.maxEnemyHP * 0.08) {
+                screenShake(14, 420);
+              }
             }
           }
           enemyState.pendingDamage = 0;

--- a/style.css
+++ b/style.css
@@ -294,6 +294,32 @@ canvas {
   animation: rise 1s ease-out forwards;
   z-index: 11;
 }
+.critical-text {
+  position: absolute;
+  color: #ffe066;
+  text-shadow: 0 0 8px rgba(255, 80, 80, 0.95);
+  font-weight: 900;
+  font-size: 24px;
+  letter-spacing: 1px;
+  pointer-events: none;
+  animation: rise 0.85s ease-out forwards;
+  z-index: 14;
+}
+.combo-banner {
+  position: absolute;
+  top: 15%;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 16px;
+  border: 2px solid #fff;
+  border-radius: 10px;
+  color: #fff;
+  font-weight: 800;
+  background: linear-gradient(90deg, #ff1493, #ff7a00);
+  animation: comboPop 0.55s ease-out forwards;
+  pointer-events: none;
+  z-index: 13;
+}
 
 .heal-text {
   color: #32cd32;
@@ -359,6 +385,16 @@ canvas {
   animation: boom 0.5s ease-out forwards;
   z-index: 9;
 }
+.bomb-ripple {
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 180, 80, 0.8);
+  pointer-events: none;
+  animation: bombRipple 0.55s ease-out forwards;
+  z-index: 8;
+}
 @keyframes spark {
   from { transform: scale(0.5); opacity: 1; }
   to   { transform: scale(2); opacity: 0; }
@@ -383,14 +419,33 @@ canvas {
   to   { opacity: 0; }
 }
 .shake {
-  animation: shake 0.3s;
+  animation: shake var(--shake-duration, 0.3s);
 }
 @keyframes shake {
   0% { transform: translate(0, 0); }
-  25% { transform: translate(-5px, 5px); }
-  50% { transform: translate(5px, -5px); }
-  75% { transform: translate(-5px, -5px); }
+  25% { transform: translate(calc(var(--shake-intensity, 8px) * -1), var(--shake-intensity, 8px)); }
+  50% { transform: translate(var(--shake-intensity, 8px), calc(var(--shake-intensity, 8px) * -1)); }
+  75% { transform: translate(calc(var(--shake-intensity, 8px) * -1), calc(var(--shake-intensity, 8px) * -1)); }
   100% { transform: translate(0, 0); }
+}
+@keyframes bombRipple {
+  from { transform: scale(0.4); opacity: 1; }
+  to { transform: scale(1.7); opacity: 0; }
+}
+@keyframes comboPop {
+  0% { opacity: 0; transform: translateX(-50%) scale(0.8); }
+  20% { opacity: 1; transform: translateX(-50%) scale(1.05); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(-16px) scale(1); }
+}
+.enemy-hit-flash {
+  filter: brightness(1.7) saturate(1.3);
+}
+.enemy-hit-shake {
+  animation: enemyHitShake 0.2s ease-in-out 2;
+}
+@keyframes enemyHitShake {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(-6px); }
 }
 #victory-overlay {
   position: absolute;

--- a/ui.js
+++ b/ui.js
@@ -678,8 +678,10 @@ export function selectNextBall(firePoint) {
 
 export function flashEnemyDamage(enemyState) {
   const { damageImage, normalImage, enemyHP } = enemyState;
+  enemyGirl.classList.add('enemy-hit-flash', 'enemy-hit-shake');
   enemyGirl.src = damageImage;
   setTimeout(() => {
+    enemyGirl.classList.remove('enemy-hit-flash', 'enemy-hit-shake');
     if (enemyHP > 0) {
       enemyGirl.src = normalImage;
     }
@@ -719,8 +721,33 @@ export function showBombExplosion(x, y) {
   boom.className = 'bomb-explosion';
   boom.style.left = `${x - 80}px`;
   boom.style.top = `${y - 80}px`;
-  document.getElementById('game-wrapper').appendChild(boom);
+  const ripple = document.createElement('div');
+  ripple.className = 'bomb-ripple';
+  ripple.style.left = `${x - 80}px`;
+  ripple.style.top = `${y - 80}px`;
+  const wrapper = document.getElementById('game-wrapper');
+  wrapper.appendChild(ripple);
+  wrapper.appendChild(boom);
+  setTimeout(() => ripple.remove(), 550);
   setTimeout(() => boom.remove(), 500);
+}
+
+export function showCriticalText(x, y) {
+  const txt = document.createElement('div');
+  txt.className = 'critical-text';
+  txt.textContent = 'CRITICAL!';
+  txt.style.left = `${x - 40}px`;
+  txt.style.top = `${y - 44}px`;
+  document.getElementById('game-wrapper').appendChild(txt);
+  setTimeout(() => txt.remove(), 850);
+}
+
+export function showComboBanner(combo) {
+  const banner = document.createElement('div');
+  banner.className = 'combo-banner';
+  banner.textContent = `COMBO x${combo}`;
+  document.getElementById('game-wrapper').appendChild(banner);
+  setTimeout(() => banner.remove(), 550);
 }
 
 export function showDamageOverlay() {
@@ -739,9 +766,15 @@ export function showDamageOverlay() {
 }
 
 export function shakeContainer() {
+  screenShake(8, 300);
+}
+
+export function screenShake(intensity = 8, duration = 300) {
   const cont = document.getElementById('container');
+  cont.style.setProperty('--shake-intensity', `${intensity}px`);
+  cont.style.setProperty('--shake-duration', `${duration}ms`);
   cont.classList.add('shake');
-  setTimeout(() => cont.classList.remove('shake'), 300);
+  setTimeout(() => cont.classList.remove('shake'), duration);
 }
 
 export function launchHeartAttack() {


### PR DESCRIPTION
### Motivation
- 戦闘の手応えを強めるために、クリティカルと高コンボ時の視覚フィードバックを追加したよ〜。
- 爆弾の演出を派手にして当たり判定感を出したかったの〜。
- 大ダメージ時に画面全体でドカンと伝わる演出（強いスクリーンシェイク）を入れて臨場感を上げたよ〜。

### Description
- `ui.js` に `showCriticalText`, `showComboBanner`, `screenShake(intensity, duration)` を追加して演出を分離したよ〜。
- `showBombExplosion` を波紋要素 `bomb-ripple` として別レイヤで表示するように変更したよ〜。
- `flashEnemyDamage` で `#enemy-girl` に短時間 `enemy-hit-flash` と `enemy-hit-shake` クラスを付与して被弾時のフラッシュ/シェイクを付けたよ〜。
- `engine.js` の `calculateHitDamage` を `(damage, isCritical)` を返す形にしてクリティカル判定を伝搬し、クリティカル時に `CRITICAL!` 表示、コンボが `>=10` のときに `COMBO xN` バナーを表示し、確定ダメージが敵最大HPの `8%` 以上なら強い `screenShake(14,420)` を発火するようにしたよ〜。
- `style.css` に `critical-text` / `combo-banner` / `bomb-ripple` / `enemy-hit-*` 等のスタイルと、`--shake-intensity` / `--shake-duration` を使った可変シェイク実装を追加したよ〜。

### Testing
- 自動構文チェックで `node --check ui.js` が成功したよ〜。
- 自動構文チェックで `node --check engine.js` が成功したよ〜。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b8982ed08330a2bb828027852feb)