### PR TITLE
サイドパネルに戦闘ステータス追加と統一更新関数を実装

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1,4 +1,4 @@
-import { showBombExplosion, showComboBanner, showCriticalText, showDamageText, showHealSpark, showHitSpark, launchHeartAttack, screenShake, updateCoins, updateShotStats } from './ui.js';
+import { showBombExplosion, showComboBanner, showCriticalText, showDamageText, showHealSpark, showHitSpark, launchHeartAttack, screenShake, updateCoins, updateShotStats, updateCombatStats } from './ui.js';
 import { updateCurrentBall } from './ui.js';
 import { updateAttackCountdown } from './ui.js';
 import { playerState } from './player.js';
@@ -389,6 +389,7 @@ function handlePegHit(peg, ball) {
   if (pegType === 'rainbow') {
     shotCombo += 5;
     updateShotStats(shotCombo, shotTotalDamage);
+    updateCombatStats();
   }
 }
 
@@ -498,6 +499,7 @@ export function setupCollisionHandler() {
           enemyState.pendingDamage = 0;
           shotTotalDamage = 0;
           updateShotStats(shotCombo, shotTotalDamage);
+          updateCombatStats();
           playerState.currentShotType = null;
           currentShotHits = 0;
           enemyState.attackCountdown--;

--- a/index.html
+++ b/index.html
@@ -69,8 +69,13 @@
         <img id="enemy-girl" src="" alt="enemy">
         <div id="enemy-attack-timer"></div>
         <div id="stage-display">Stage: <span id="stage-value">1</span></div>
-        <div id="combo-display">現在コンボ: <span id="current-combo-value">0</span></div>
-        <div id="shot-damage-display">1ショット合計ダメージ: <span id="shot-total-damage-value">0</span></div>
+        <div id="enemy-hp-display">Enemy HP/Max HP: <span id="enemy-hp-value">200 / 200</span></div>
+        <div id="base-damage-display">Base Damage: <span id="base-damage-value">0</span></div>
+        <div id="combo-bonus-display">Combo Bonus: <span id="combo-bonus-value">0</span></div>
+        <div id="multiball-display">Multiball: <span id="multiball-value">1</span></div>
+        <div id="critical-rate-display">Critical Rate: <span id="critical-rate-value">0%</span></div>
+        <div id="combo-display">Current Combo: <span id="current-combo-value">0</span></div>
+        <div id="shot-damage-display">Shot Total: <span id="shot-total-damage-value">0</span></div>
       </div>
     </div>
     <div id="victory-overlay">

--- a/ui.js
+++ b/ui.js
@@ -39,6 +39,11 @@ const upgradeCardOptions = document.getElementById('upgrade-card-options');
 const stageValue = document.getElementById('stage-value');
 const currentComboValue = document.getElementById('current-combo-value');
 const shotTotalDamageValue = document.getElementById('shot-total-damage-value');
+const enemyHpValue = document.getElementById('enemy-hp-value');
+const baseDamageValue = document.getElementById('base-damage-value');
+const comboBonusValue = document.getElementById('combo-bonus-value');
+const multiballValue = document.getElementById('multiball-value');
+const criticalRateValue = document.getElementById('critical-rate-value');
 
 const mainMenu = document.getElementById('main-menu');
 const skillTreeButton = document.getElementById('skill-tree-button');
@@ -175,6 +180,7 @@ function showUpgradeCardOverlay(enemyState, onDone) {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       card.apply();
+      updateCombatStats();
       upgradeCardOverlay.classList.remove('show');
       enemyState.stage += 1;
       startStage(enemyState.nodeType);
@@ -186,13 +192,27 @@ function showUpgradeCardOverlay(enemyState, onDone) {
 }
 
 
+
+export function updateCombatStats(state = {}) {
+  if (stageValue) stageValue.textContent = String(state.stage ?? stageValue.textContent ?? '1');
+  if (enemyHpValue && hpDisplay) enemyHpValue.textContent = hpDisplay.textContent;
+  if (baseDamageValue) baseDamageValue.textContent = String(state.baseDamage ?? playerState.baseDamage ?? 0);
+  if (comboBonusValue) comboBonusValue.textContent = String(state.comboBonus ?? playerState.comboBonus ?? 0);
+  if (multiballValue) multiballValue.textContent = String(state.multiballCount ?? playerState.multiballCount ?? 1);
+  if (criticalRateValue) {
+    const rate = state.critRate ?? playerState.critRate ?? 0;
+    criticalRateValue.textContent = `${Math.round(rate * 100)}%`;
+  }
+  if (currentComboValue) currentComboValue.textContent = String(Math.max(0, state.currentCombo ?? 0));
+  if (shotTotalDamageValue) shotTotalDamageValue.textContent = String(Math.max(0, Math.round(state.shotTotalDamage ?? 0)));
+}
+
 export function updateShotStats(combo, totalDamage) {
-  if (currentComboValue) currentComboValue.textContent = String(Math.max(0, combo));
-  if (shotTotalDamageValue) shotTotalDamageValue.textContent = String(Math.max(0, Math.round(totalDamage)));
+  updateCombatStats({ currentCombo: combo, shotTotalDamage: totalDamage });
 }
 
 export function updateStageDisplay(stage) {
-  if (stageValue) stageValue.textContent = stage;
+  updateCombatStats({ stage });
 }
 
 
@@ -209,6 +229,7 @@ export function updateHPBar(enemyState) {
   const hp = Math.max(0, Math.ceil(enemyState.enemyHP));
   hpText.textContent = `${hp}`;
   hpDisplay.textContent = `${hp} / ${Math.ceil(enemyState.maxEnemyHP)}`;
+  updateCombatStats();
   if (enemyState.enemyHP <= 0 && !enemyState.gameOver) {
     enemyState.gameOver = true;
     let coinsEarned = enemyState.stage * 3;
@@ -795,4 +816,4 @@ export function updateMapDisplay(state) {
 }
 
 updateCoins();
-updateShotStats(0, 0);
+updateCombatStats({ currentCombo: 0, shotTotalDamage: 0 });


### PR DESCRIPTION
### Motivation
- サイドパネルにStage以外の戦闘ステータス（Enemy HP/Max HP, Base Damage, Combo Bonus, Multiball, Critical Rate, Current Combo, Shot Total）を表示してプレイ中に即時確認できるようにするためだよ〜。
- 敵HP表示は既存の `#hp-display` を参照して二重管理を避けつつ、表示更新を一元化したかったの。

### Description
- `index.html` に新しいステータス行を追加して、Enemy HP/Max HP／Base Damage／Combo Bonus／Multiball／Critical Rate／Current Combo／Shot Total を表示するようにしたよ。 (ファイル: `index.html`)
- `ui.js` に `updateCombatStats(state)` を新規追加して、ステージ／敵HP文字列／プレイヤー系ステータス／コンボ／ショット合計を一括更新するようにしたよ。 (ファイル: `ui.js`)
- 既存の `updateShotStats` と `updateStageDisplay` を `updateCombatStats` 経由にして、ショットヒット時・ショット終了時・ステージ開始・カード選択後に表示を更新するように組み込んだよ（`engine.js` の該当箇所で呼び出しを追加）。 (ファイル: `engine.js`, `ui.js`)
- 敵HP表示は `#hp-display` のテキストをそのまま参照して `enemyHP/maxHP` を更新する設計にして、状態の二重管理をしないようにしてるよ。 (ファイル: `ui.js`)

### Testing
- `node --check ui.js` を実行して構文チェックは成功したよ〜。
- `node --check engine.js` を実行して構文チェックは成功したよ〜。
- `node --check enemy.js` を実行して構文チェックは成功したよ〜。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b994e20483309e54783b903666bf)